### PR TITLE
Change config options to arguments and allow nesting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
   - poetry install -vvv
   - hush_keygen --name test
-  - poetry run jsctl config update --name=private_key_path --value="`pwd`/test.priv"
+  - poetry run jsctl config update private_key_path "`pwd`/test.priv"
   - poetry run pytest tests/ -s --cov=jumpscale
 
 after_success:

--- a/docs/api/jumpscale/core/base/factory.html
+++ b/docs/api/jumpscale/core/base/factory.html
@@ -32,7 +32,10 @@ store = filesystem
 </code></pre>
 <p>Get all stores configurations:</p>
 <pre><code>✗ jsctl config get stores
-stores = {'redis': {'hostname': 'localhost', 'port': 6379}, 'filesystem': {'path': '/home/abom/.config/jumpscale/secureconfig'}}
+redis.hostname = "localhost"
+redis.port = 6379
+filesystem.path = "/home/abom/.config/jumpscale/secureconfig"
+whoosh.path = "/home/abom/.config/jumpscale/whoosh_indexes"
 </code></pre>
 <p>For example, set current store to redis:</p>
 <pre><code>jsctl config update store redis

--- a/docs/api/jumpscale/core/base/factory.html
+++ b/docs/api/jumpscale/core/base/factory.html
@@ -27,15 +27,15 @@
 <li><a title="jumpscale.core.base.factory.StoredFactory" href="#jumpscale.core.base.factory.StoredFactory"><code>StoredFactory</code></a>: a factory which stores and load configuration according to the current configured store backend.</li>
 </ul>
 <p>Default store configured is file system, you can show current store config by doing:</p>
-<pre><code>✗ jsctl config get --name store
+<pre><code>✗ jsctl config get store
 store = filesystem
 </code></pre>
 <p>Get all stores configurations:</p>
-<pre><code>✗ jsctl config get --name stores
+<pre><code>✗ jsctl config get stores
 stores = {'redis': {'hostname': 'localhost', 'port': 6379}, 'filesystem': {'path': '/home/abom/.config/jumpscale/secureconfig'}}
 </code></pre>
 <p>For example, set current store to redis:</p>
-<pre><code>jsctl config update --name store --value redis
+<pre><code>jsctl config update store redis
 </code></pre>
 <p>This will use current redis config (hostname: localhost, port: 6379).</p>
 <details class="source">
@@ -52,21 +52,21 @@ It is implemented using:
 Default store configured is file system, you can show current store config by doing:
 
 ```
-✗ jsctl config get --name store
+✗ jsctl config get store
 store = filesystem
 ```
 
 Get all stores configurations:
 
 ```
-✗ jsctl config get --name stores
+✗ jsctl config get stores
 stores = {&#39;redis&#39;: {&#39;hostname&#39;: &#39;localhost&#39;, &#39;port&#39;: 6379}, &#39;filesystem&#39;: {&#39;path&#39;: &#39;/home/abom/.config/jumpscale/secureconfig&#39;}}
 ```
 
 For example, set current store to redis:
 
 ```
-jsctl config update --name store --value redis
+jsctl config update store redis
 ```
 
 This will use current redis config (hostname: localhost, port: 6379).

--- a/docs/wiki/configmgmt.md
+++ b/docs/wiki/configmgmt.md
@@ -176,7 +176,7 @@ There is a key that's auto-generated for you, to generate a new key, use `hush_k
 
 ```
 hush_keygen --name test
-jsctl config update --name=private_key_path --value="`pwd`/test.priv"
+jsctl config update private_key_path "`pwd`/test.priv"
 ```
 
 Only secret fields are encrypted by default, so, if you have a password field for example, it's better to use `fields.Secret` for it:

--- a/docs/wiki/stores.md
+++ b/docs/wiki/stores.md
@@ -32,7 +32,7 @@ We now support multiple storage backend, every backend stores the data different
 Selecting any of them can be done using the configuration file, or using `jsctl`:
 
 ```bash
-jsctl config update --name store --value redis
+jsctl config update store redis
 ```
 
 Each store have related configuration:

--- a/jumpscale/core/base/factory.py
+++ b/jumpscale/core/base/factory.py
@@ -10,21 +10,21 @@ It is implemented using:
 Default store configured is file system, you can show current store config by doing:
 
 ```
-✗ jsctl config get --name store
+✗ jsctl config get store
 store = filesystem
 ```
 
 Get all stores configurations:
 
 ```
-✗ jsctl config get --name stores
+✗ jsctl config get stores
 stores = {'redis': {'hostname': 'localhost', 'port': 6379}, 'filesystem': {'path': '/home/abom/.config/jumpscale/secureconfig'}}
 ```
 
 For example, set current store to redis:
 
 ```
-jsctl config update --name store --value redis
+jsctl config update store redis
 ```
 
 This will use current redis config (hostname: localhost, port: 6379).

--- a/jumpscale/core/base/factory.py
+++ b/jumpscale/core/base/factory.py
@@ -18,7 +18,10 @@ Get all stores configurations:
 
 ```
 ✗ jsctl config get stores
-stores = {'redis': {'hostname': 'localhost', 'port': 6379}, 'filesystem': {'path': '/home/abom/.config/jumpscale/secureconfig'}}
+redis.hostname = "localhost"
+redis.port = 6379
+filesystem.path = "/home/abom/.config/jumpscale/secureconfig"
+whoosh.path = "/home/abom/.config/jumpscale/whoosh_indexes"
 ```
 
 For example, set current store to redis:

--- a/jumpscale/entry_points/jsctl.py
+++ b/jumpscale/entry_points/jsctl.py
@@ -1,10 +1,25 @@
 import click
 
 from jumpscale.core.config import get_default_config, update_config, get_config
+import toml
+
+
+def decode_toml_value(s):
+    try:
+        return toml.TomlDecoder().load_value(s)[0]
+    except ValueError:
+        return s
+
+
+def encode_toml_value(s):
+    return toml.TomlEncoder().dump_value(s)
 
 
 def format_config_parameter(name, value):
-    return "%s = %s" % (name, str(value))
+    if isinstance(value, dict):
+        print_dict(value, "")
+    else:
+        return "%s = %s" % (name, encode_toml_value(value))
 
 
 def print_dict(data, path):
@@ -12,7 +27,8 @@ def print_dict(data, path):
         if isinstance(value, dict):
             print_dict(value, f"{path}{name}.")
         else:
-            print(f"{path}{name} = {value}")
+            encoded = encode_toml_value(value)
+            print(f"{path}{name} = {encoded}")
 
 
 def format_config(config):
@@ -48,9 +64,14 @@ def list_all():
 @config.command()
 @click.argument("name")
 def get(name):
-    _, obj, prop = traverse_config(name)
-    value = obj[prop]
-    click.echo(format_config_parameter(name, value))
+    try:
+        _, obj, prop = traverse_config(name)
+        if not isinstance(obj, dict):
+            raise KeyError()
+        value = obj[prop]
+        click.echo(format_config_parameter(name, value))
+    except KeyError:
+        click.echo("Key doens't exist")
 
 
 @config.command()
@@ -59,14 +80,14 @@ def get(name):
 def update(name, value):
     try:
         config, obj, prop = traverse_config(name)
-        obj[prop] = value
+        if not isinstance(obj, dict) or prop not in obj:
+            raise KeyError()
+        obj[prop] = decode_toml_value(value)
         update_config(config)
     except KeyError:
-        config = get_config()
-        config[name] = value
-        update_config(config)
-
-    click.echo("Updated.")
+        click.echo("Key doen't exist")
+    else:
+        click.echo("Updated.")
 
 
 @click.group()

--- a/jumpscale/entry_points/jsctl.py
+++ b/jumpscale/entry_points/jsctl.py
@@ -57,10 +57,14 @@ def get(name):
 @click.argument("name")
 @click.argument("value")
 def update(name, value):
-    config, obj, prop = traverse_config(name)
-    obj[prop] = value
-
-    update_config(config)
+    try:
+        config, obj, prop = traverse_config(name)
+        obj[prop] = value
+        update_config(config)
+    except KeyError:
+        config = get_config()
+        config[name] = value
+        update_config(config)
 
     click.echo("Updated.")
 

--- a/jumpscale/entry_points/jsctl.py
+++ b/jumpscale/entry_points/jsctl.py
@@ -11,6 +11,15 @@ def format_config(config):
     return "\n".join([format_config_parameter(name, value) for name, value in config.items()])
 
 
+def traverse_config(name):
+    path = name.split(".")
+    config = get_config()
+    prop = config
+    for i, p in enumerate(path[:-1]):
+        prop = prop[p]
+    return config, prop, path[-1]
+
+
 @click.group()
 def config():
     pass
@@ -27,18 +36,20 @@ def list_all():
 
 
 @config.command()
-@click.option("--name")
+@click.argument("name")
 def get(name):
-    value = get_config()[name]
+    _, obj, prop = traverse_config(name)
+    value = obj[prop]
     click.echo(format_config_parameter(name, value))
 
 
 @config.command()
-@click.option("--name")
-@click.option("--value")
+@click.argument("name")
+@click.argument("value")
 def update(name, value):
-    config = get_config()
-    config[name] = value
+    config, obj, prop = traverse_config(name)
+    obj[prop] = value
+
     update_config(config)
 
     click.echo("Updated.")

--- a/jumpscale/entry_points/jsctl.py
+++ b/jumpscale/entry_points/jsctl.py
@@ -39,8 +39,6 @@ def traverse_config(name):
     path = name.split(".")
     config = get_config()
     prop = config
-    if name in config:
-        return config, prop, name
     for i, p in enumerate(path[:-1]):
         prop = prop[p]
     return config, prop, path[-1]

--- a/jumpscale/entry_points/jsctl.py
+++ b/jumpscale/entry_points/jsctl.py
@@ -11,22 +11,13 @@ def decode_toml_value(s):
         return s
 
 
-def get_toml_value_type(s):
-    try:
-        print(s)
-        print(toml.TomlDecoder().load_value(s))
-        return toml.TomlDecoder().load_value(s)[1]
-    except Exception:
-        return "str"
-
-
 def encode_toml_value(s):
     return toml.TomlEncoder().dump_value(s)
 
 
 def format_config_parameter(name, value):
     if isinstance(value, dict):
-        print_dict(value, "")
+        print_dict(value, f"{name}.")
     else:
         return "%s = %s" % (name, encode_toml_value(value))
 
@@ -40,7 +31,7 @@ def print_dict(data, path):
             print(f"{path}{name} = {encoded}")
 
 
-def validate_type_homogeneity(a, b):
+def validate_type(a, b):
     typea = type(a).__name__
     typeb = type(b).__name__
     if typea != typeb:
@@ -101,7 +92,7 @@ def update(name, value):
         if not isinstance(obj, dict) or prop not in obj:
             raise KeyError()
         value = decode_toml_value(value)
-        validate_type_homogeneity(obj[prop], value)
+        validate_type(obj[prop], value)
         obj[prop] = value
         update_config(config)
     except KeyError:

--- a/jumpscale/entry_points/jsctl.py
+++ b/jumpscale/entry_points/jsctl.py
@@ -7,14 +7,24 @@ def format_config_parameter(name, value):
     return "%s = %s" % (name, str(value))
 
 
+def print_dict(data, path):
+    for name, value in data.items():
+        if isinstance(value, dict):
+            print_dict(value, f"{path}{name}.")
+        else:
+            print(f"{path}{name} = {value}")
+
+
 def format_config(config):
-    return "\n".join([format_config_parameter(name, value) for name, value in config.items()])
+    print_dict(config, "")
 
 
 def traverse_config(name):
     path = name.split(".")
     config = get_config()
     prop = config
+    if name in config:
+        return config, prop, name
     for i, p in enumerate(path[:-1]):
         prop = prop[p]
     return config, prop, path[-1]
@@ -27,12 +37,12 @@ def config():
 
 @config.command()
 def defaults():
-    click.echo(format_config(get_default_config()))
+    format_config(get_default_config())
 
 
 @config.command()
 def list_all():
-    click.echo(format_config(get_config()))
+    format_config(get_config())
 
 
 @config.command()


### PR DESCRIPTION
Resolves  #390.
Receive config get and update as arguments rather than options.
Allow accessing and modifying nested properties.