### PR TITLE
base: fix resolving fields from super classes...

### DIFF
--- a/jumpscale/core/base/meta.py
+++ b/jumpscale/core/base/meta.py
@@ -167,19 +167,19 @@ class BaseMeta(type):
             type: a new class
         """
         # will collect class fields
-        # and also all fields of super classes, as we already have them in based
         cls_fields = {}
-        super_fields = {}
 
+        # get all fields from super classes, we have them ordered in `based`
+        # make sure not to re-add any field that's already added
+        # otherwise, fields will be resolved disorderly
         for super_cls in based:
             if hasattr(super_cls, "_fields"):
-                super_fields.update(super_cls._fields)
+                for name, field in super_cls._fields.items():
+                    if name not in attrs:
+                        attrs[name] = field
 
-        # update current attrs with super class fields
-        attrs.update(super_fields)
-
-        # now we maintain old attributes, but convert any attribute
-        # with fields.Field type to property descriptor (property object)
+        # now we maintain old attributes, but convert any attribute with
+        # fields.Field type to property descriptor (property object)
         # using get_field_property
         new_attrs = {}
         for key in attrs:

--- a/tests/core/base/test_fields_with_base.py
+++ b/tests/core/base/test_fields_with_base.py
@@ -296,7 +296,7 @@ class TestBaseWithFields(unittest.TestCase):
 
     def test_field_resolution_multiple_inheritance_without_child_field_defined(self):
         """
-        Test for field resolution in case of multuple inheritance without the same field in ChildWithMultipleParents and ChildWithMultipleParentsWithDifferntOrder
+        Test for field resolution in case of multiple inheritance without the same field in ChildWithMultipleParents and ChildWithMultipleParentsWithDifferntOrder
 
         **Test Scenario**
 
@@ -313,7 +313,7 @@ class TestBaseWithFields(unittest.TestCase):
 
     def test_field_resolution_multiple_inheritance_with_child_field_defined(self):
         """
-        Test for field resolution in case of multuple inheritance with the same field defined in ChildWithMultipleParentsAndTheSameField
+        Test for field resolution in case of multiple inheritance with the same field defined in ChildWithMultipleParentsAndTheSameField
 
         **Test Scenario**
 

--- a/tests/core/base/test_fields_with_base.py
+++ b/tests/core/base/test_fields_with_base.py
@@ -257,35 +257,38 @@ class TestBaseWithFields(unittest.TestCase):
         parent_a_field = ParentA()._get_fields()["name"]
         parent_b_field = ParentB()._get_fields()["name"]
         child_field = Child()._get_fields()["name"]
-
         self.assertEqual(parent_a_field.default, "A")
         self.assertEqual(parent_b_field.default, "B")
         self.assertEqual(child_field.default, "B")
 
         # (2)
-        class Child(ParentB):
+        class ChildWithTheSameField(ParentB):
             name = fields.String(default="C")
 
-        child_field = Child()._get_fields()["name"]
-
+        child_field = ChildWithTheSameField()._get_fields()["name"]
         self.assertEqual(child_field.default, "C")
 
         # (3)
-        class ParentB(Base):
+        class ParentBM(Base):
             name = fields.String(default="B")
 
-        class Child(ParentA, ParentB):
+        class ChildWithMultipleParents(ParentA, ParentBM):
             pass
 
-        parent_b_field = ParentB()._get_fields()["name"]
-        child_field = Child()._get_fields()["name"]
-
+        parent_b_field = ParentBM()._get_fields()["name"]
+        child_field = ChildWithMultipleParents()._get_fields()["name"]
         self.assertEqual(parent_b_field.default, "B")
         self.assertEqual(child_field.default, "A")
 
+        class ChildWithMultipleParentsWithDifferntOrder(ParentBM, ParentA):
+            pass
+
+        child_field = ChildWithMultipleParentsWithDifferntOrder()._get_fields()["name"]
+        self.assertEqual(child_field.default, "B")
+
         # (4)
-        class Child(ParentA, ParentB):
+        class ChildWithMultipleParentsAndTheSameField(ParentA, ParentBM):
             name = fields.String(default="C")
 
-        child_field = Child()._get_fields()["name"]
+        child_field = ChildWithMultipleParentsAndTheSameField()._get_fields()["name"]
         self.assertEqual(child_field.default, "C")


### PR DESCRIPTION
### Description

It changes/fixes how we get/update super-class fields into current class fields in `Base` implementation in the correct order.

### Changes

- Add tests to cover possible scenarios.
- Update `BaseMeta.__new__` to handle getting fields from super classes in the correct order, also, to not to overwrite current class defined fields with it.

### Related Issues

#465 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Code format and docstrings
