### PR TITLE
config: get version from metadata

### DIFF
--- a/jumpscale/core/config/config.py
+++ b/jumpscale/core/config/config.py
@@ -61,8 +61,6 @@ JS-NG> j.core.config.set("favcolor", "grey")
 JS-NG> j.core.config.get("favcolor")
 'grey'
 ```
-
-
 """
 
 import os
@@ -70,10 +68,18 @@ import os
 import nacl.utils
 import nacl.encoding
 import pytoml as toml
+
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata as metadata
+
 from nacl.public import PrivateKey
 
 
 __all__ = [
+    "__version__",
     "config_path",
     "config_root",
     "get_default_config",
@@ -86,7 +92,9 @@ __all__ = [
     "get_current_version",
 ]
 
-__version__ = "11.0b3"
+
+package_name = "js-ng"
+__version__ = metadata.version(package_name)
 
 
 config_root = os.path.expanduser(os.path.join("~/.config", "jumpscale"))
@@ -180,12 +188,12 @@ def set(key, val):
 
 
 def set_default(key, val):
-    """ Sets key to value in jumpscale config and returns 
+    """ Sets key to value in jumpscale config and returns
 
     Arguments:
         key (str): the key you wish to update
         val: value to update with and to return if key doesn't exist in configurations
-    
+
     Returns:
         val (str): returned if key doesn't exist in configuration or the value of key in configurations
     """
@@ -195,8 +203,6 @@ def set_default(key, val):
     else:
         set(key, val)
         return val
-
-
 
 
 def migrate_config():


### PR DESCRIPTION
### Description

Get version from package metatdata, according to https://github.com/python-poetry/poetry/issues/273 and https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-package-version.

This will make `pyproject.toml` as single source for package versioning.

### Changes

Change `core/config.py` version to be set from package metadata and expose it too.

### Related Issues

None

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
