### PR TITLE
version 11.0b5

### DIFF
--- a/jumpscale/core/config/config.py
+++ b/jumpscale/core/config/config.py
@@ -79,7 +79,6 @@ from nacl.public import PrivateKey
 
 
 __all__ = [
-    "__version__",
     "config_path",
     "config_root",
     "get_default_config",

--- a/jumpscale/entry_points/jsng.py
+++ b/jumpscale/entry_points/jsng.py
@@ -7,13 +7,15 @@ import pathlib
 import sys
 
 from jumpscale.loader import j  # noqa:
-from jumpscale.core.config.config import get_config
+from jumpscale.core.config import get_config, get_current_version
+
 
 BASE_CONFIG_DIR = os.path.join(os.environ.get("HOME", "/root"), ".jsng")
 HISTORY_FILENAME = os.path.join(BASE_CONFIG_DIR, "history.txt")
 
 
 @click.command()
+@click.version_option(get_current_version())
 @click.argument("command", required=False)
 def run(command):
     """Executes the passed command and initiates a jsng shell if no command is passed."""
@@ -23,10 +25,12 @@ def run(command):
         config = get_config()
         if config["shell"] == "ipython":
             from IPython import embed
+
             sys.exit(embed(colors="neutral"))
         else:
             from jumpscale.shell import ptconfig
             from ptpython.repl import embed
+
             sys.exit(embed(globals(), locals(), configure=ptconfig, history_filename=HISTORY_FILENAME))
     else:
         sys.exit(print(exec(command)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "js-ng"
 packages = [{ include = "jumpscale" }]
-version = "11.0b4"
+version = "11.0b5"
 description = "system automation, configuration management and RPC framework"
 authors = ["xmonader <xmonader@gmail.com>"]
 license = "MIT"
@@ -70,10 +70,9 @@ jsync = "jumpscale.entry_points.jsync:cli"
 line-length = 120
 target_version = ['py37']
 
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
 [tool.pytest.ini_options]
 markers = ["integration: marks tests as integration (deselect with '-m \"not integration\"')",
            "unittests"]
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
### Description

Bump version to 11.0b5 and add version option to `jsng` entry point.

### Changes

`core/config.py` and `jsng.py` entry point.

### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
