### PR TITLE
Add get traceback helper in error handler to be used elsewhere

### DIFF
--- a/jumpscale/tools/errorhandler/errorhandler.py
+++ b/jumpscale/tools/errorhandler/errorhandler.py
@@ -34,11 +34,49 @@ class ErrorHandler:
             frame = frame.tb_next
         return stacktrace
 
-    def _handle_exception(self, ttype, tvalue, tb, level=40, die=False, log=True, category="", data=None):
-        timestamp = j.data.time.now().timestamp
+    def get_traceback(self, exc_info=None):
+        """Get a trackback information as a dict, suitable to used with error/alert handlers
+
+        if `exe_info` is not passed, `sys.exc_info()` will be used instead.
+
+        Example traceback information:
+
+        ```
+        {
+            'process_id': 20840,
+            'raw': 'Traceback (most recent call last):\n  File "<stdin>", line 1, in <module>\nValueError: a is not valid',
+            'straceback': [
+                {
+                    'code': '',
+                    'context': '<module>',
+                    'filename': '<stdin>',
+                    'filepath': '<stdin>',
+                    'linenr': 1
+                }
+            ]
+        }
+        ```
+
+        Args:
+            exc_info (tuple, optional): exception information as a tuple (ttype, tvalue, tb). Defaults to None.
+
+        Returns:
+            dict: raw and stacktrace information as a dict, alongside process id
+        """
+        if exc_info:
+            ttype, tvalue, tb = exc_info
+        else:
+            ttype, tvalue, tb = sys.exc_info()
+
         stacktrace = self._construct_stacktrace(tb)
-        message = self._format_lines(traceback.format_exception_only(ttype, tvalue))
         traceback_text = self._format_lines(traceback.format_exception(ttype, tvalue, tb))
+
+        return {"raw": traceback_text, "straceback": stacktrace, "process_id": j.application.process_id}
+
+    def _handle_exception(self, ttype, tvalue, tb, level=40, die=False, log=True, category="", data=None):
+        exc_info = (ttype, tvalue, tb)
+        timestamp = j.data.time.now().timestamp
+        message = self._format_lines(traceback.format_exception_only(ttype, tvalue))
 
         err_dict = {
             "appname": j.application.appname,
@@ -47,11 +85,11 @@ class ErrorHandler:
             "timestamp": timestamp,
             "category": category or "exception",
             "data": data,
-            "traceback": {"raw": traceback_text, "stacktrace": stacktrace, "process_id": j.application.process_id},
+            "traceback": self.get_traceback(exc_info),
         }
 
         if log:
-            exception = (ttype, tvalue, tb)
+            exception = exc_info
             j.logger.exception(message=message, category=category, data=data, level=level, exception=exception)
 
         for handler_func, handler_level in self.handlers:

--- a/jumpscale/tools/errorhandler/errorhandler.py
+++ b/jumpscale/tools/errorhandler/errorhandler.py
@@ -71,7 +71,7 @@ class ErrorHandler:
         stacktrace = self._construct_stacktrace(tb)
         traceback_text = self._format_lines(traceback.format_exception(ttype, tvalue, tb))
 
-        return {"raw": traceback_text, "straceback": stacktrace, "process_id": j.application.process_id}
+        return {"raw": traceback_text, "stacktrace": stacktrace, "process_id": j.application.process_id}
 
     def _handle_exception(self, ttype, tvalue, tb, level=40, die=False, log=True, category="", data=None):
         exc_info = (ttype, tvalue, tb)


### PR DESCRIPTION
### Description
Retrieve from the alertandler tools traceback and stacktrace of the last exception to be able to add in alerts raised if needed by adding a helper in error handler

### Changes

Add helper to get the traceback to be used individually from alertshandler and errorshandler

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/1639

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
