### PR TITLE
gedis: support loading actor modules directly...

### DIFF
--- a/jumpscale/core/config/config.py
+++ b/jumpscale/core/config/config.py
@@ -88,12 +88,26 @@ __all__ = [
     "get",
     "set",
     "set_default",
+    "get_package_version",
     "get_current_version",
 ]
 
 
+def get_package_version(name):
+    """
+    get installed package version by name
+
+    Args:
+        name (str): package name
+
+    Returns:
+        str: installed package version
+    """
+    return metadata.version(name)
+
+
 package_name = "js-ng"
-__version__ = metadata.version(package_name)
+__version__ = get_package_version(package_name)
 
 
 config_root = os.path.expanduser(os.path.join("~/.config", "jumpscale"))


### PR DESCRIPTION
### Description

Support loading actors by modules, remove loading actor modules on client side for now and trying to support custom types without reloading.

### Changes

* Server
  - Flag actors property as non-stored
  - Expose `register_actor` and `unregister_actor` methods to be used instead of the system actor.
  - Add register_actor_module to register a loaded module directly.
  - Show a deprecation warning in system actor register/unregister methods
  - Added more tests for loading module directly

* Client
  - Remove loading actor modules in the client
  - Removed `partial` call when returning actor's proxy function and update its name

 

* TODO
  - Implement something like a type registry to allow custom types between client <-> server, this way, we won't load all server side code in the client side, but send these type info from the server and re-create them in the client.

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
