### PR TITLE
chore: Modify workflow at jsng-ci.yml to run tests with a variety of Python versions

### DIFF
--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -12,8 +12,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Gathering deps
         run: |
           sudo apt-get update

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y git python3-pip python3-venv python3-setuptools tmux redis
+          sudo apt-get install -y git python3-setuptools tmux redis
           sudo pip3 install poetry
       - name: Install
         run: |


### PR DESCRIPTION
### Description

Using the setup-python action is the recommended way of using Python with GitHub Actions because it ensures consistent behavior across different runners and different versions of Python, instead of using The default version that may vary between GitHub-hosted runners, which may cause unexpected changes or to use an older version than expected.

### Changes

1- switch from using the default version set in `PATH` to use setup-python action with configured matrix, to run the workflow on a variety of Python versions. more specific python 3.6, 3.7 and 3.8 

2- discard pip3 and venv from being installed as dependencies, as both are part of the Python standard library since 3.3 and 3.4 releases and we only run the workflow on 3.6+ 

### Related Issues

List of related issues

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
