### PR TITLE
Add cors header and options to gedis http server

### DIFF
--- a/jumpscale/servers/gedis_http/__init__.py
+++ b/jumpscale/servers/gedis_http/__init__.py
@@ -16,7 +16,7 @@ class GedisHTTPServer(Base):
         super().__init__(*args, **kwargs)
         self._app = Bottle()
         self._client = None
-        self._app.route("/<package>/<actor>/<method>", ["GET", "POST"], self.handler)
+        self._app.route("/<package>/<actor>/<method>", ["GET", "POST", "OPTIONS"], self.enable_cors(self.handler))
 
     @property
     def client(self):
@@ -29,6 +29,21 @@ class GedisHTTPServer(Base):
         response.status = code
         response.content_type = "application/json"
         return json.dumps(content)
+
+    def enable_cors(self, fn):
+        def _enable_cors(*args, **kwargs):
+            # set CORS headers
+            response.headers["Access-Control-Allow-Origin"] = "*"
+            response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, OPTIONS, DELETE"
+            response.headers[
+                "Access-Control-Allow-Headers"
+            ] = "Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token"
+
+            if request.method != "OPTIONS":
+                # actual request; reply with the actual response
+                return fn(*args, **kwargs)
+
+        return _enable_cors
 
     def handler(self, package, actor, method):
         actors = self.client.actors

--- a/jumpscale/servers/gedis_http/__init__.py
+++ b/jumpscale/servers/gedis_http/__init__.py
@@ -19,7 +19,7 @@ class GedisHTTPServer(Base):
         self._client = None
         http_methods = ["GET", "POST"]
         if self.allow_cors:
-            http_methods.append("OPTIONS")
+            http_methods.extend(["OPTIONS", "PUT", "DELETE"])
         self._app.route("/<package>/<actor>/<method>", http_methods, self.enable_cors(self.handler, self.allow_cors))
 
     @property


### PR DESCRIPTION
### Description

- Options method is not supported
- CORS headers are not supported in gedis http server

### Changes
Add suport for OPTIONs method, and add CORS headers

#### Test changes:
- Enabling cors headers(default)
```python
GedisHTTPServer(
  instance_name='testing',
  host='127.0.0.1',
  port=4500,
  allow_cors=True
)
```
```
curl -i -v  -X OPTIONS http://127.0.0.1:4500/testing/cors/enabled
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4500 (#0)
> OPTIONS /testing/cors/enabled HTTP/1.1
> Host: 127.0.0.1:4500
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS, DELETE
Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS, DELETE
< Access-Control-Allow-Headers: Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token
Access-Control-Allow-Headers: Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token
< Content-Length: 0
Content-Length: 0
< Content-Type: text/html; charset=UTF-8
Content-Type: text/html; charset=UTF-8
< Date: Sun, 03 Jan 2021 14:51:45 GMT
Date: Sun, 03 Jan 2021 14:51:45 GMT

< 
* Connection #0 to host 127.0.0.1 left intact

```
- Disabling cors headers
```python
GedisHTTPServer(
  instance_name='testing2',
  host='127.0.0.1',
  port=4600,
  allow_cors=False
)
```
```
 curl -i -v  -X OPTIONS http://127.0.0.1:4600/testing/cors/enabled
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4600 (#0)
> OPTIONS /testing/cors/enabled HTTP/1.1
> Host: 127.0.0.1:4600
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 405 Method Not Allowed
HTTP/1.1 405 Method Not Allowed
< Allow: GET,POST
Allow: GET,POST
< Content-Length: 753
Content-Length: 753
< Content-Type: text/html; charset=UTF-8
Content-Type: text/html; charset=UTF-8
< Date: Sun, 03 Jan 2021 14:52:02 GMT
Date: Sun, 03 Jan 2021 14:52:02 GMT

< 

    <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
    <html>
        <head>
            <title>Error: 405 Method Not Allowed</title>
            <style type="text/css">
              html {background-color: #eee; font-family: sans;}
              body {background-color: #fff; border: 1px solid #ddd;
                    padding: 15px; margin: 15px;}
              pre {background-color: #eee; border: 1px solid #ddd; padding: 5px;}
            </style>
        </head>
        <body>
            <h1>Error: 405 Method Not Allowed</h1>
            <p>Sorry, the requested URL <tt>&#039;http://127.0.0.1:4600/testing/cors/enabled&#039;</tt>
               caused an error:</p>
            <pre>Method not allowed.</pre>
        </body>
    </html>
* Connection #0 to host 127.0.0.1 left intact

```


### Related Issues
https://github.com/threefoldtech/js-sdk/issues/2110
https://github.com/threefoldfoundation/tft-stellar/issues/257

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
