### PR TITLE
Update jsng-ci.yml to use multiple ubuntu versions

### DIFF
--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -17,13 +17,15 @@ jobs:
       fail-fast: false
       max-parallel: 9
       matrix:
-        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-18.04]
+        python-version: [3.6, 3.7, 3.8]
         experimental: [false]
         include:
           - python-version: 3.9
+            os: ${{ matrix.os }}
             experimental: true
           - os: ubuntu-20.04
+            python-versiob: ${{ matrix.python-version }}
             experimental: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -24,9 +24,11 @@ jobs:
           - os: ubuntu-20.04
             python-version: 3.8
             experimental: true
+            name: Experimental testing - Ubuntu 20.04 (Python 3.8)
           - python-version: 3.9
             os: ubuntu-18.04
             experimental: true
+            name: Experimental testing - Python 3.9 (Ubuntu 18.04)
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -24,11 +24,11 @@ jobs:
           - os: ubuntu-20.04
             python-version: 3.8
             experimental: true
-            name: Experimental testing - Ubuntu 20.04 (Python 3.8)
+            name: Experimental build - latest Ubuntu
           - python-version: 3.9
             os: ubuntu-18.04
             experimental: true
-            name: Experimental testing - Python 3.9 (Ubuntu 18.04)
+            name: Experimental build - latest Python
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -11,9 +11,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -12,10 +12,19 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
+      max-parallel: 9
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-18.04]
+        experimental: [false]
+        include:
+          - python-version: 3.9
+            experimental: true
+          - os: ubuntu-20.04
+            experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -22,6 +22,10 @@ jobs:
         experimental: [false]
         include:
           - os: ubuntu-20.04
+            python-version: 3.8
+            experimental: true
+          - python-version: 3.9
+            os: ubuntu-18.04
             experimental: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -22,10 +22,8 @@ jobs:
         experimental: [false]
         include:
           - python-version: 3.9
-            os: ${{ matrix.os }}
             experimental: true
           - os: ubuntu-20.04
-            python-versiob: ${{ matrix.python-version }}
             experimental: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -15,14 +15,12 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
-      max-parallel: 9
+      # max-parallel: 9
       matrix:
         os: [ubuntu-18.04]
         python-version: [3.6, 3.7, 3.8]
         experimental: [false]
         include:
-          - python-version: 3.9
-            experimental: true
           - os: ubuntu-20.04
             experimental: true
     steps:

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y git python3-setuptools tmux redis
+          sudo apt-get install -y git python3-setuptools tmux redis net-tools
           sudo pip3 install poetry
       - name: Install
         run: |


### PR DESCRIPTION
as currently, our CI build fails on ubuntu 20.04, this PR makes these changes to our workflow (fix the issue and also introduce important improvements):

- running ci workflow on Ubuntu 18.04 instead of ubuntu-latest, so CI build will not break when soon github-hosted runner servers switch to use ubuntu 20.04 as latest. see #535 and #540
- including additional matrix values into combinations. ubuntu 20.04 and python 3.9 as only experimental jobs (provides us with insight about the code compatibility) as Experimental testing is crucial for verifying and validating the results of all our development efforts and the current compatibility and back-compatibility status of the project.
- Prevents a workflow run from failing when an experimental job fails (ubuntu 20.04 and python 3.9).
- prevent GitHub cancels all in-progress jobs if any matrix job fails, to allow us to know the results for all jobs, even if one of the jobs fails. this is important to give insights about the issue, and if it will fail on all jobs or it is platform related issue.
- 
### Related Issues

#535
#540
#521

## Important note regard PR checks failing on CI:

the main idea to use continue-on-error is that if an allowed job failure fails (such as in the case of experimental jobs in this workflow), it means that that job should get a red X, but the overall workflow should not.
however, on the PR page, it's rather confusing, and it looks like the CI broke when it did not and actually the whole workflow is still marked as successful when looking in the Actions tab (see the screenshot).

this is because of an ongoing open issue on GitHub Actions repo: https://github.com/actions/toolkit/issues/399. so we can merge this PR and benefit from the improvements of the suggested CI workflow and - for now - ignore the UI indication in the PR page as the main jobs passed, and only experimental job/s was failed.

![Screenshot from 2021-01-11 19-06-57](https://user-images.githubusercontent.com/42457449/104214754-8753fa80-5440-11eb-8854-576e54f58890.png)

![Screenshot from 2021-01-11 17-28-10](https://user-images.githubusercontent.com/42457449/104214765-89b65480-5440-11eb-9779-8ae8ed80c30e.png)




