### PR TITLE
sals.process cleanup/refactor

### DIFF
--- a/docs/api/jumpscale/sals/index.html
+++ b/docs/api/jumpscale/sals/index.html
@@ -39,11 +39,7 @@ Using System Fs …</p></section>
 </dd>
 <dt><code class="name"><a title="jumpscale.sals.process" href="process/index.html">jumpscale.sals.process</a></code></dt>
 <dd>
-<section class="desc"><p>This module execute process on system and manage them
-for example
-```
-to create a process
-rc, out, err = j.sals.process.execute("ls", cwd="/tmp", …</p></section>
+<section class="desc"><p>This module execute process on system and manage them …</p></section>
 </dd>
 <dt><code class="name"><a title="jumpscale.sals.testdocs" href="testdocs/index.html">jumpscale.sals.testdocs</a></code></dt>
 <dd>

--- a/docs/api/jumpscale/sals/process/index.html
+++ b/docs/api/jumpscale/sals/process/index.html
@@ -5,11 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.6.4" />
 <title>jumpscale.sals.process API documentation</title>
-<meta name="description" content="This module execute process on system and manage them
-for example
-```
-to create a process
-rc, out, err = j.sals.process.execute(&#34;ls&#34;, cwd=&#34;/tmp&#34;, …" />
+<meta name="description" content="This module execute process on system and manage them …" />
 <link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
 <link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
@@ -24,63 +20,60 @@ rc, out, err = j.sals.process.execute(&#34;ls&#34;, cwd=&#34;/tmp&#34;, …" />
 <h1 class="title">Module <code>jumpscale.sals.process</code></h1>
 </header>
 <section id="section-intro">
-<p>This module execute process on system and manage them
-for example</p>
-<pre><code>#to create a process
-rc, out, err = j.sals.process.execute(&quot;ls&quot;, cwd=&quot;/tmp&quot;, showout=True)
-#this executes ls command on dir &quot;/tmp&quot; showing output from stdout
-#rc -&gt; contains exit status
-#out -&gt; the actual output
-#err -&gt; in case an error happened this var will contains the error msg
-
-j.sals.process.is_active(10022)
-#checks if a process with this pid is active or not
-
-j.sals.process.kill(10022, sig=signal.SIGTERM.value)
-#kill a process with pid 10022 with SIGTERM
-
-j.sals.process.get_pid_by_port(8000)
-#gets pid of the process listenning on port 8000
+<p>This module execute process on system and manage them</p>
+<h2 id="example">Example</h2>
+<p>```</p>
+<h1 id="to-create-a-process">to create a process</h1>
+<pre><code>&gt;&gt;&gt; from jumpscale.loader import j
+&gt;&gt;&gt; rc, out, err = j.sals.process.execute("ls", cwd="/tmp", showout=True)
+# this executes ls command on dir "/tmp" showing output from stdout
+</code></pre>
+<h1 id="rc-contains-exit-status">rc -&gt; contains exit status</h1>
+<h1 id="out-the-actual-output">out -&gt; the actual output</h1>
+<h1 id="err-in-case-an-error-happened-this-var-will-contains-the-error-msg">err -&gt; in case an error happened this var will contains the error msg</h1>
+<h1 id="checks-if-a-process-with-this-pid-is-exists-in-the-current-process-list">checks if a process with this pid is exists in the current process list</h1>
+<pre><code>&gt;&gt;&gt; j.sals.process.is_alive(10022)
+</code></pre>
+<h1 id="kill-a-process-with-pid-10022-with-sigterm">kill a process with pid 10022 with SIGTERM</h1>
+<pre><code>&gt;&gt;&gt; j.sals.process.kill(10022)
+</code></pre>
+<h1 id="gets-pid-of-the-process-listenning-on-port-8000">gets pid of the process listenning on port 8000</h1>
+<pre><code>&gt;&gt;&gt; j.sals.process.get_pid_by_port(8000)
+```
 </code></pre>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">&#34;&#34;&#34;This module execute process on system and manage them
-for example
-```
-#to create a process
-rc, out, err = j.sals.process.execute(&#34;ls&#34;, cwd=&#34;/tmp&#34;, showout=True)
-#this executes ls command on dir &#34;/tmp&#34; showing output from stdout
-#rc -&gt; contains exit status
-#out -&gt; the actual output
-#err -&gt; in case an error happened this var will contains the error msg
 
-j.sals.process.is_active(10022)
-#checks if a process with this pid is active or not
+Example:
+    ```
+    #to create a process
+    &gt;&gt;&gt; from jumpscale.loader import j
+    &gt;&gt;&gt; rc, out, err = j.sals.process.execute(&#34;ls&#34;, cwd=&#34;/tmp&#34;, showout=True)
+    # this executes ls command on dir &#34;/tmp&#34; showing output from stdout
+    # rc -&gt; contains exit status
+    # out -&gt; the actual output
+    # err -&gt; in case an error happened this var will contains the error msg
 
-j.sals.process.kill(10022, sig=signal.SIGTERM.value)
-#kill a process with pid 10022 with SIGTERM
+    # checks if a process with this pid is exists in the current process list
+    &gt;&gt;&gt; j.sals.process.is_alive(10022)
 
-j.sals.process.get_pid_by_port(8000)
-#gets pid of the process listenning on port 8000
-```
+    # kill a process with pid 10022 with SIGTERM
+    &gt;&gt;&gt; j.sals.process.kill(10022)
+
+    # gets pid of the process listenning on port 8000
+    &gt;&gt;&gt; j.sals.process.get_pid_by_port(8000)
+    ```
 &#34;&#34;&#34;
 
 
 import math
 import os
-import os.path
-import random
-import re
-import select
-import signal
 import subprocess
-import sys
-import time
+import re
+import signal
 from collections import defaultdict
-from subprocess import Popen
-
 import psutil
-import socket
 from jumpscale.loader import j
 
 
@@ -95,26 +88,23 @@ def execute(
     replace_env=False,
     die=False,
 ):
-    &#34;&#34;&#34;
-    execute a command.
+    &#34;&#34;&#34;Execute a command.
 
-    accepts command as a list too, with auto-escaping.
+    Accepts command as a list too, with auto-escaping.
 
-    Arguments:
-        cmd (str or list): command to be executed, e.g. `&#34;ls -la&#34;` or `[&#34;ls&#34;, &#34;-la&#34;]
-
-    Keyword Arguments:
-        showout (bool): show stdout of the command (default: False)
-        cwd (str): specify a working directory for the command (default: None)
-        shell (str): specify a shell to execute the command (default: &#34;/bin/bash&#34;)
-        timeout (int): timeout before kill the process (default: 600)
-        asynchronous (bool): execute in asynchronous mode or not (default: False)
-        env (dict): add environment variables here (default: {})
-        replace_env (bool): replace entire environment with env (default: False)
-        die (bool): die if command failed (default: False)
+    Args:
+        cmd (str/list[str]): Command to be executed, e.g. &#34;ls -la&#34; or [&#34;ls&#34;, &#34;-la&#34;]
+        showout (bool, optional): Whether to show stdout of the command or not. Defaults to False.
+        cwd (str, optional): Path to `cd` into before running command. Defaults to None.
+        shell (str, optional): Specify a working directory for the command. Defaults to &#34;/bin/bash&#34;.
+        timeout (int, optional): Timeout before kill the process. Defaults to 600.
+        asynchronous (bool, optional): Whether to execute in asynchronous mode or not. Defaults to False.
+        env (dict, optional): Add environment variables here. Defaults to None.
+        replace_env (bool, optional): Whether to replace the entire environment with env. Defaults to False.
+        die (bool, optional): Whether to raise exception if command failed or not. Defaults to False.
 
     Returns:
-        tuple: (rc, out, err)
+        tuple: tuple[return_code: int, stdout: str, stderr: str]
     &#34;&#34;&#34;
     return j.core.executors.run_local(
         cmd=cmd,
@@ -130,339 +120,402 @@ def execute(
 
 
 def is_alive(pid):
-    &#34;&#34;&#34;Checks if pid is Running
+    &#34;&#34;&#34;Check whether the given PID exists in the current process list.
 
-    Arguments:
-        pid (int) -- pid of the process to be checked
+    Args:
+        pid (int): Process ID (PID) to be checked.
 
     Returns:
-        [bool] -- True if process is running
+        bool: True if the given PID exists in the current process list, False otherwise.
     &#34;&#34;&#34;
-    pid = int(pid)
     return psutil.pid_exists(pid)
 
 
 def is_installed(cmd):
-    &#34;&#34;&#34;[summary]
-    Checks if a specific command is available on system e.g. curl
-    Arguments:
-        cmd {str} -- command to be checked
+    &#34;&#34;&#34;Checks if a specific command is available on system e.g. curl.
+
+    Args:
+        cmd (str): Command to be checked.
 
     Returns:
-        [bool] -- True if command is installed
+        bool: True if command is available, False otherwise.
     &#34;&#34;&#34;
-    rc, _, _ = execute(&#34;which %s&#34; % cmd, die=False)
-    if rc:
-        return False
-    else:
-        return True
+    rc, _, _ = execute(f&#34;which {cmd}&#34;, die=False)
+    return rc == 0
 
 
-def kill(pid, sig=signal.SIGTERM.value):
-    &#34;&#34;&#34;Kill a process with a signal
+def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
+    &#34;&#34;&#34;Kill a process with a specified signal.
 
-    Arguments:
-        pid (int) -- pid of the process to be killed
-
-    Keyword Arguments:
-        sig {int]} -- which signal you want to kill the process with (default: {signal.SIGTERM.value})
+    Args:
+        proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Raises:
-        j.exceptions.RuntimeError: in case killing process failed
+        j.exceptions.Runtime: In case killing the process failed.
+        j.exceptions.Permission: In case the permission to perform this action is denied.
 
     Returns:
-        [type] -- [description]
+        None
     &#34;&#34;&#34;
-    pid = int(pid)
-    sig = int(sig)
-    proc = psutil.Process(pid)
     try:
+        if isinstance(proc, int):
+            proc = get_process_object(proc)
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            return True
         proc.send_signal(sig)
+        # Wait for a process to terminate
+        # If PID no longer exists return None immediately
+        # If timeout exceeded and the process is still alive raise TimeoutExpired exception
+        proc.wait(timeout=timeout)
+        j.logger.debug(f&#34;the process with PID: {proc.pid} was terminated with sig: {sig}.&#34;)
+        return True  # XXX only to pass current tests
+    except psutil.TimeoutExpired as e:
+        # timeout expires and process is still alive.
+        if sure_kill and sig != signal.SIGKILL and os.name != &#34;nt&#34;:
+            # SIGKILL not supported in windows
+            # If a process gets this signal it must quit immediately and will not perform any clean-up operations
+            proc.kill()
+            j.logger.debug(&#34;SIGKILL signal sent.&#34;)
+            try:
+                proc.wait(1)
+                j.logger.debug(f&#34;the process with PID: {proc.pid} was terminated with sig: {signal.SIGKILL}.&#34;)
+            except psutil.TimeoutExpired as e:
+                if proc.status() == psutil.STATUS_ZOMBIE:
+                    j.logger.debug(
+                        f&#34;the process with PID: {proc.pid} becomes a zombie and should be considered a dead.&#34;
+                    )
+                    return True
+                # the process may be in an uninterruptible sleep
+                j.logger.debug(&#34;the process may be in an uninterruptible sleep.&#34;)
+                j.logger.warning(f&#34;Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}&#34;)
+                raise j.exceptions.Runtime(f&#34;Could not kill process with pid {proc.pid}, {proc.status()}&#34;) from e
+            return True  # XXX only to pass current tests
+        else:
+            j.logger.warning(f&#34;Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}&#34;)
+            raise j.exceptions.Runtime(f&#34;Could not kill process with pid {proc.pid}&#34;) from e
+    except psutil.AccessDenied as e:
+        # permission to perform an action is denied
+        j.logger.warning(&#34;the permission is denied&#34;)
+        raise j.exceptions.Permission(&#34;Permission to perform this action is denied!&#34;) from e
+    except (psutil.ZombieProcess, psutil.NoSuchProcess):
+        # Process no longer exists or Zombie (already dead)
+        j.logger.debug(&#34;Process is no longer exists or a Zombie (already dead)&#34;)
         return True
-    except Exception as e:
-        raise j.exceptions.RuntimeError(&#34;Could not kill process with id %s.\n%s&#34; % (pid, e))
 
 
-def ps_find(name):
-    &#34;&#34;&#34;find process by name
+def ps_find(process_name):
+    &#34;&#34;&#34;Check if there is any running process that match the given name.
 
-    Arguments:
-        name {str} -- process name
+    Args:
+        process_name (str): The target process name. will match against against Process.name(),\
+            Process.exe() and Process.cmdline()
 
     Returns:
-        [bool] -- True if process is found
+        bool: True if process is found, False otherwise.
     &#34;&#34;&#34;
-    for proc in psutil.process_iter():
-        if proc.name() == name:
-            return True
-    return False
+    return len(get_pids(process_name, limit=1)) == 1
 
 
-def kill_all(name, sig=signal.SIGKILL):
-    &#34;&#34;&#34;Kill all processes with a given name
+def kill_all(process_name, sig=signal.SIGKILL):
+    &#34;&#34;&#34;Kill all processes that match &#39;process_name&#39;.
 
-    Arguments:
-        name {str} -- process name
+    Args:
+        process_name (str): The target process name
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL
 
-    Keyword Arguments:
-        sig (int) -- signal number (default: {signal.SIGKILL})
+    Returns:
+        None or list[int] represents the IDs of the processes remaning alive.
     &#34;&#34;&#34;
-    sig = int(sig)
-    for proc in psutil.process_iter():
-        if proc.name() == name:
-            kill(proc.pid, sig)
+    # XXX kill default to SIGTERM while kill_all default to SIGKILL (inconsistency)?
+    # XXX almost like kill_process_by_name
+    failed_processes = kill_process_by_name(process_name, sig)
+    return failed_processes
 
 
 def get_pids_filtered_sorted(filterstr, sortkey=None):
     &#34;&#34;&#34;Get pids of process by a filter string and optionally sort by sortkey
 
-    Arguments:
-        filterstr {[str]} -- filter string.
-
-    Keyword Arguments:
-        sortkey {[str]} -- sort key for ps command (default: {None})
-        sortkey can be one of the following:
-        %cpu           cpu utilization of the process in
-        %mem           ratio of the process&#39;s resident set size  to the physical memory on the machine, expressed as a percentage.
-        cputime        cumulative CPU time, &#34;[DD-]hh:mm:ss&#34; format.  (alias time).
-        egid           effective group ID number of the process as a decimal integer.  (alias gid).
-        egroup         effective group ID of the process.  This will be the textual group ID, if it can be obtained and the field width permits, or a decimal representation otherwise.  (alias group).
-        euid           effective user ID (alias uid).
-        euser          effective user name.
-        gid            see egid.  (alias egid).
-        pid            a number representing the process ID (alias tgid).
-        ppid           parent process ID.
-        psr            processor that process is currently assigned to.
-        start_time     starting time or date of the process.
-
+    Args:
+        filterstr (str): filter string.
+        sortkey (str, optional): Defaults to None. (if no sortkey used it will sort by pid(s) ascending).
+            sortkey can be one of the following:
+            %cpu           cpu utilization of the process in
+            %mem           ratio of the process&#39;s resident set size  to the physical memory on the machine, expressed as a percentage.
+            cputime        cumulative CPU time, &#34;[DD-]hh:mm:ss&#34; format.  (alias time).
+            egid           effective group ID number of the process as a decimal integer.  (alias gid).
+            egroup         effective group ID of the process. This will be the textual group ID, if it can be obtained and the field width permits, or a decimal representation otherwise.  (alias group).
+            euid           effective user ID (alias uid).
+            euser          effective user name.
+            gid            see egid. (alias egid).
+            pid            a number representing the process ID (alias tgid).
+            ppid           parent process ID.
+            psr            processor that process is currently assigned to.
+            start_time     starting time or date of the process.
 
     Returns:
-        [list(int)] -- processes pids
+        list(int): processes pids
     &#34;&#34;&#34;
-    if sortkey is not None:
-        cmd = &#34;ps aux --sort={sortkey} | grep &#39;{filterstr}&#39;&#34;.format(filterstr=filterstr, sortkey=sortkey)
+    ps_to_psutil_map = {
+        &#34;%cpu&#34;: &#34;cpu_percent&#34;,
+        &#34;%mem&#34;: &#34;memory_percent&#34;,
+        &#34;cputime&#34;: &#34;cpu_time&#34;,
+        &#34;psr&#34;: &#34;cpu_num&#34;,
+        &#34;start_time&#34;: &#34;create_time&#34;,
+        &#34;egid&#34;: &#34;egid&#34;,
+        &#34;gid&#34;: &#34;egid&#34;,
+        &#34;euid&#34;: &#34;euid&#34;,
+        &#34;uid&#34;: &#34;euid&#34;,
+        &#34;euser&#34;: &#34;username&#34;,
+        &#34;pid&#34;: &#34;pid&#34;,
+        &#34;ppid&#34;: &#34;ppid&#34;,
+    }
+    if sortkey is None:  # mimic default ps commnad sorting behavior
+        sortkey = &#34;pid&#34;
+        desc = False
     else:
-        cmd = &#34;ps ax | grep &#39;{filterstr}&#39;&#34;.format(filterstr=filterstr)
-    rc, out, err = execute(cmd)
-    # print out
-    found = []
-    for line in out.split(&#34;\n&#34;):
-        if line.find(&#34;grep&#34;) != -1 or line.strip() == &#34;&#34;:
-            continue
-        if line.strip() != &#34;&#34;:
-            if line.find(filterstr) != -1:
-                line = line.strip()
-                if sortkey is not None:
-                    found.append(int([x for x in line.split(&#34; &#34;) if x][1]))
-                else:
-                    found.append(int(line.split(&#34; &#34;)[0]))
-    return found
+        desc = True
+    # return pids from process objects
+    return [p[&#34;pid&#34;] for p in get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)]
 
 
 def get_filtered_pids(filterstr, excludes=None):
-    &#34;&#34;&#34;Get pids filtered by filterstr and execludes
+    &#34;&#34;&#34;Get pids filtered by filterstr and excludes
 
-    Arguments:
-        filterstr {str} -- filter string.
-
-    Keyword Arguments:
-        excludes {list(str)} -- execlude list (default: {None})
+    Args:
+        filterstr (str): the String to filter based on.
+        excludes (list[str]): exclude list. Defaults to None.
 
     Returns:
-        [list(int)] -- pids
+        list[int]: list of pids
     &#34;&#34;&#34;
-    excludes = excludes or []
-    cmd = &#34;ps ax | grep &#39;%s&#39;&#34; % filterstr
-    rc, out, err = j.core.executors.run_local(cmd)
-    # print out
-    found = []
+    pids = []
+    try:
+        for proc in psutil.process_iter([&#34;name&#34;, &#34;cmdline&#34;]):
+            cmd_line = &#34; &#34;.join(proc.info[&#34;cmdline&#34;])
+            if proc.info[&#34;cmdline&#34;] and filterstr in cmd_line:
+                j.logger.debug(f&#34;found filter string: {filterstr} in command line: {cmd_line}&#34;)
+                if excludes:
+                    for exclude in excludes:
+                        if exclude in cmd_line:
+                            j.logger.debug(
+                                f&#34;but excluded because it contain exclude string: {exclude} in command line: {cmd_line}&#34;
+                            )
+                            break
+                    else:  # intended `for/else` meaning for loop finished normally with no break
+                        pids.append(proc.pid)  # may yield proc instead
+                    continue
+                else:
+                    pids.append(proc.pid)  # may yield proc instead
+        j.logger.debug(
+            f&#34;founded pids are: {pids}&#34;
+            if pids
+            else f&#34;filter string {filterstr} not found in any processes. root needed?&#34;
+        )
+        return pids
+    except (psutil.AccessDenied, psutil.NoSuchProcess) as e:
+        j.logger.debug(&#34;logging and bypassing the exception occurred while iterating over the system processes&#34;)
+        j.logger.exception(&#34;exception occurred while iterating over the system processes&#34;, exception=e)
+        pass
 
-    def checkexclude(c, excludes):
-        for item in excludes:
-            c = c.lower()
-            if c.find(item.lower()) != -1:
-                return True
-        return False
 
-    for line in out.split(&#34;\n&#34;):
-        if line.find(&#34;grep&#34;) != -1 or line.strip() == &#34;&#34;:
-            continue
-        if line.strip() != &#34;&#34;:
-            if line.find(filterstr) != -1:
-                line = line.strip()
-                if not checkexclude(line, excludes):
-                    # print &#34;found pidline:%s&#34;%line
-                    found.append(int(line.split(&#34; &#34;)[0]))
-    return found
+def get_pids_filtered_by_regex(regex_list):
+    &#34;&#34;&#34;Get pids of a process filtered by Regex list
 
-
-def get_pids_filtered_by_regex(regex_list, excludes=None):
-    &#34;&#34;&#34;get pids of a process filtered by Regex list
-
-    Arguments:
-        regex_list {list(str)} -- list of regex expressions
-
-    Keyword Arguments:
-        excludes {list(str)} -- list of excludes (default: {None})
+    Args:
+        regex_list (list[str]): List of regex expressions.
 
     Returns:
-        [list(int)] -- list of pids
+        list(int): List of pids.
     &#34;&#34;&#34;
-    excludes = excludes or []
     res = []
-    for process in psutil.process_iter():
-        try:
-            cmdline = process.cmdline()
-        except psutil.NoSuchProcess:
-            cmdline = None
-        except psutil.AccessDenied:
-            cmdline = None
-        if cmdline:
-            name = &#34; &#34;.join(cmdline)
+    for process in psutil.process_iter(attrs=[&#34;cmdline&#34;]):
+        if process.info[&#34;cmdline&#34;]:
+            cmdline = &#34; &#34;.join(process.info[&#34;cmdline&#34;])
             for r in regex_list:
-                if name.strip() != &#34;&#34; and re.match(r, name):
+                if re.match(r, cmdline):
                     res.append(process.pid)
     return res
 
 
-def check_start(cmd, filterstr, nrinstances=1, retry=1):
-    &#34;&#34;&#34;Run command and check if it is started based on filterstr
+def check_start(cmd, filterstr, n_instances=1, retry=1):
+    &#34;&#34;&#34;Run command (possibly multiple times) and check if it is started based on filterstr
 
-    Arguments:
-        cmd {str} -- command to be executed
-        filterstr {str} -- filter string
-
-    Keyword Arguments:
-        instances (int) -- number of needed instances (default: {1})
-        retry (int) -- number of retries (default: {1})
+    Args:
+        cmd (str/list): Command to be executed.
+        filterstr (str): Filter string. will match against against Process.name(),\
+            Process.exe() and Process.cmdline()
+        n_instances (int, optional): Number of needed instances. Defaults to 1.
+        retry (int, optional): Number of retries to execute the command and check. Defaults to 1.
 
     Raises:
-        j.exceptions.RuntimeError: will be raised if we didn&#39;t reach number of required instances
+        j.exceptions.Runtime: will be raised if we didn&#39;t reach number of required instances.
     &#34;&#34;&#34;
-    found = get_filtered_pids(filterstr)
     for i in range(retry):
-        if len(found) == nrinstances:
-            return
-        # print &#34;START:%s&#34;%cmd
-        execute(cmd)
-        time.sleep(1)
-    found = get_filtered_pids(filterstr)
-    if len(found) != nrinstances:
-        raise j.exceptions.RuntimeError(
-            &#34;could not start %s, found %s nr of instances. Needed %s.&#34; % (cmd, len(found), nrinstances)
-        )
+        if isinstance(cmd, str):
+            cmd = cmd.split()
+        proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        j.logger.debug(f&#34;attempt no: {i}&#34;)
+        j.logger.debug(f&#34;executed cmd: {cmd}&#34;)
+        j.logger.debug(f&#34;proc.cmdline: {proc.cmdline()}&#34;)
+        j.logger.debug(f&#34;pid: {proc.pid}&#34;)
+        j.logger.debug(f&#34;status: {proc.status()}&#34;)
+        j.logger.debug(f&#34;name: {proc.name()}&#34;)
+        j.logger.debug(f&#34;exe: {proc.exe()}&#34;)
+        j.logger.debug(f&#34;children: {proc.children(recursive=True)}&#34;)
+        j.logger.debug(f&#34;parents: {proc.parents()}&#34;)
+        try:
+            rc = proc.wait(timeout=1)  # makesure the process is stable
+            if rc == 0:  # executing the command succeeded but exited immediately!
+                j.logger.debug(&#34;executing the start command succeeded but exited immediately&#34;)
+            else:
+                j.logger.debug(&#34;the start command exited with error&#34;)  # the process exited with error
+            j.logger.debug(f&#34;return code is: {rc}&#34;)
+        except psutil.TimeoutExpired:
+            j.logger.debug(&#34;the start command still running after 1 sec&#34;)  # still running
+        # TODO check based on command
+        if check_running(filterstr, min=n_instances):
+            j.logger.debug(f&#34;found at least {n_instances} instances using the filter string: {filterstr}&#34;)
+            return True  # XXX should remove? None
+        else:
+            j.logger.debug(f&#34;the required number of instances using the filter string: {filterstr} not found yet!&#34;)
+            continue
+    j.logger.error(f&#34;could not start the required number of instances ({n_instances}) after {i} attempts.&#34;)
+    raise j.exceptions.Runtime(&#34;could not start the required number of instances.&#34;)
 
 
-def check_stop(cmd, filterstr, retry=1, nrinstances=0):
-    &#34;&#34;&#34;Executes a stop command and check if it is already stopped based on filterstr
+def check_stop(cmd, filterstr, retry=1, n_instances=0):
+    &#34;&#34;&#34;Executes a stop command (possibly multiple times) and check if it is already stopped based on filterstr
 
-    Arguments:
-        cmd {str} -- command to be executed
-        filterstr {str} -- filter string
-
-    Keyword Arguments:
-        retry (int) -- number of retries (default: {1})
-        nrinstances (int) -- number of instances after stop (default: {0})
+    Args:
+        cmd (str): Command to be executed.
+        filterstr (str): Filter string.
+        retry (int, optional): Number of retries. Defaults to 1.
+        n_inst (int, optional): Number of instances after stop. Defaults to 0.
 
     Raises:
-        j.exceptions.RuntimeError: if nr of instances not matched
+        j.exceptions.Runtime: if number of instances not matched
     &#34;&#34;&#34;
 
-    found = get_filtered_pids(filterstr)
     for i in range(retry):
-        if len(found) == nrinstances:
-            return
-        # print &#34;START:%s&#34;%cmd
-        execute(cmd, die=False)
-        time.sleep(1)
-        found = get_filtered_pids(filterstr)
-        for item in found:
-            kill(int(item), 9)
-        found = get_filtered_pids(filterstr)
+        if isinstance(cmd, str):
+            cmd = cmd.split()
+        proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        j.logger.debug(f&#34;attempt no: {i}&#34;)
+        j.logger.debug(f&#34;executed cmd: {cmd}&#34;)
+        j.logger.debug(f&#34;proc.cmdline: {proc.cmdline()}&#34;)
+        j.logger.debug(f&#34;pid: {proc.pid}&#34;)
+        j.logger.debug(f&#34;status: {proc.status()}&#34;)
+        j.logger.debug(f&#34;name: {proc.name()}&#34;)
+        j.logger.debug(f&#34;exe: {proc.exe()}&#34;)
+        j.logger.debug(f&#34;children: {proc.children(recursive=True)}&#34;)
+        j.logger.debug(f&#34;parents: {proc.parents()}&#34;)
+        try:
+            rc = proc.wait(timeout=5)  # makesure the process is stable
+            # print(f&#39;rc: {rc}&#39;)
+            if rc == 0:
+                # executing the process succeeded but exited immediately!
+                j.logger.debug(&#34;executing the stop command succeeded but exited immediately&#34;)
+            else:
+                # the process exited with error
+                j.logger.debug(&#34;the stop command exited with error&#34;)  # the process exited with error
+        except psutil.TimeoutExpired:
+            j.logger.debug(&#34;the start command still running after 1 sec&#34;)  # still running
+        found = get_pids(filterstr)
+        if len(found) == n_instances:
+            j.logger.debug(
+                f&#34;the required {n_instances} matching the instances found using the filter string: {filterstr}&#34;
+            )
+            return True  # should remove? None
+        else:
+            j.logger.debug(
+                f&#34;the required {n_instances} not matching the instances number found using the filter string: {filterstr} yet&#34;
+            )
+            continue
+    j.logger.error(f&#34;could not match the required number of instances ({n_instances}) after {i} attempts.&#34;)
+    j.logger.debug(f&#34;alive: {found}&#34;)
+    j.logger.debug(f&#34;{len(found)}&#34;)
+    raise j.exceptions.Runtime(f&#34;could not stop {cmd}, found {len(found)} of instances instead of {n_instances}&#34;)
 
-    if len(found) != 0:
-        raise j.exceptions.RuntimeError(&#34;could not stop %s, found %s nr of instances.&#34; % (cmd, len(found)))
 
+def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
+    &#34;&#34;&#34;Return a list of processes ID(s) matching &#39;process_name&#39;.
 
-def get_pids(process_name, match_predicate=None):
-    &#34;&#34;&#34;Get process ID(s) for a given process
+    Function will check string against Process.name(), Process.exe() and Process.cmdline()
 
-    Arguments:
-        process {str} -- process name
-
-    Keyword Arguments:
-        match_predicate {callable} -- function that does matching between
-        found processes and the targested process, the function should accept
-        two arguments and return a boolean, defaults to None (default: {None})
-
-    Raises:
-        j.exceptions.RuntimeError: [description]
-        j.exceptions.NotImplemented: [description]
+    Args:
+        process_name (str): The target process name
+        match_predicate (callable, optional): Function that does matching between\
+            found processes and the targeted process, the function should accept\
+            two arguments and return a boolean. Defaults to None.
+        limit (int, optional): If not equal to 0, function will return as fast as the number\
+            of PID(s) found become equal to `limit` value.
+        _alt_source(callable or iterable, optional): Can be used to specify an alternative source\
+            of the psutil.Process objects to match against.
+            ex: get_user_processes func, or get_similar_processes.
+            if not specified, psutil.process_iter will be used. Defaults to None.
 
     Returns:
-        [list(int)] -- list of pids
+        list[int]: list of PID(s)
     &#34;&#34;&#34;
     # default match predicate
-    # why aren&#39;t we using psutil ??
     def default_predicate(target, given):
-        return target.strip().lower() in given.lower()
+        j.logger.debug(f&#34;matching {target} with {given}&#34;)
+        if isinstance(given, list):
+            return target.strip().lower() in given
+        return target.strip().lower() == given.lower()
 
-    if match_predicate is None:
-        match_predicate = default_predicate
+    match_predicate = match_predicate or default_predicate
 
-    if process_name is None:
-        raise j.exceptions.RuntimeError(&#34;process cannot be None&#34;)
-    if j.data.platform.is_unix():
-        pids = set()
-        for process in get_processes():
-            try:
-                pid = process.pid
-                if not isinstance(pid, int):
-                    continue
-                name = process.name()
-                if match_predicate(process_name, name):
-                    pids.add(pid)
-                elif match_predicate(process_name, process.exe()):
-                    pids.add(pid)
-                else:
-                    cmdline = process.cmdline()
-                    if cmdline and cmdline[0]:
-                        if match_predicate(process_name, cmdline[0]):
-                            pids.add(pid)
-            except (psutil.Error, FileNotFoundError):
-                continue
-        return list(pids)
-    else:
-        raise j.exceptions.NotImplemented(&#34;getProcessPid is only implemented for unix&#34;)
+    pids = []
+    for proc in psutil.process_iter([&#34;name&#34;, &#34;exe&#34;, &#34;cmdline&#34;]):
+        try:
+            j.logger.debug(f&#34;process to check: {proc.info}&#34;)
+            if (
+                (match_predicate(process_name, proc.info[&#34;name&#34;]))
+                or (proc.info[&#34;exe&#34;] and match_predicate(process_name, os.path.basename(proc.info[&#34;exe&#34;])))
+                or (proc.info[&#34;cmdline&#34;] and match_predicate(process_name, proc.info[&#34;cmdline&#34;]))
+            ):
+                pids.append(proc.pid)
+                # return early if no need to iterate over all running process
+                if limit and len(pids) == limit:
+                    return pids
+        except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess):
+            pass
+    return pids
 
 
 def get_my_process():
-    &#34;&#34;&#34;get process object of current process
+    &#34;&#34;&#34;Get psutil.Process object of the current process.
 
     Returns:
-        [psutil.Process] -- process object
+        (psutil.Process): psutil.Process object of the current process.
     &#34;&#34;&#34;
     return get_process_object(os.getpid())
 
 
 def get_process_object(pid, die=True):
-    &#34;&#34;&#34;Get Process object of a process id
+    &#34;&#34;&#34;Get psutil.Process object of a given process ID (PID).
 
-    Arguments:
-        pid (int) -- pid of the process
-
-    Keyword Arguments:
-        die {bool} -- die if process not found (default: {True})
+    Args:
+        pid (int): Process ID (PID) to get
+        die (bool, optional): Whether to raise an exception if no process with the given PID is found in the \
+            current process list or not. Defaults to True.
 
     Raises:
-        psutil.NoSuchProcess: if process not found and die = True
+        psutil.NoSuchProcess: If process with the given PID is not found and die set to True.
+        psutil.AccessDenied: If permission denied.
 
     Returns:
-        [psutil.Process] -- process object
+        psutil.Process or None: psutil.Process object if he given PID is found, None otherwise.
     &#34;&#34;&#34;
     try:
         return psutil.Process(pid)
-    except psutil.NoSuchProcess as e:
+    except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess) as e:
+        # when you query processess owned by another user, especially on macOS and Windows you may get AccessDenied exception
         if die:
             raise e
         else:
@@ -470,255 +523,384 @@ def get_process_object(pid, die=True):
 
 
 def get_user_processes(user):
-    &#34;&#34;&#34;Get all process for a specific user
+    &#34;&#34;&#34;Get all process for a specific user.
 
-    Arguments:
-        user {str} -- username
+    Args:
+        user (str): Te user name to match against.
+
+    Yields:
+        psutil.Process: psutil.Process object for all processes owned by `user`.
+    &#34;&#34;&#34;
+    try:
+        for process in psutil.process_iter():
+            if process.username() == user:
+                yield process
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        pass
+
+
+def kill_user_processes(user, sure_kill=False):
+    &#34;&#34;&#34;Kill all processes for a specific user.
+
+    Args:
+        user (str): The user name to match against.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        [list(int)] -- list of process pids for that user
+        (list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.
     &#34;&#34;&#34;
-    result = []
-    for process in psutil.process_iter():
-        if process.username() == user:
-            result.append(process.pid)
-    return result
-
-
-def kill_user_processes(user):
-    &#34;&#34;&#34;Kill all processes for a specific user
-
-    Arguments:
-        user {str} -- username
-    &#34;&#34;&#34;
-    for pid in get_user_processes(user):
-        kill(pid)
-
-
-def get_similar_processes():
-    &#34;&#34;&#34;Gets similar processes to current process
-
-    Returns:
-        [list(psutil.Process)] -- list of similar process
-    &#34;&#34;&#34;
-    myprocess = get_my_process()
-    result = []
-    for item in psutil.process_iter():
+    failed_processes = []
+    for proc in get_user_processes(user):
         try:
-            if item.cmdline() == myprocess.cmdline():
-                result.append(item)
-        except psutil.NoSuchProcess:
-            pass
-    return result
+            kill(proc, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission) as e:
+            j.logger.exception(&#34;exception occurred while iterating over user processes&#34;, exception=e)
+            j.logger.debug(&#34;ignoring the exception..&#34;)
+            failed_processes.append(proc)
+    j.logger.debug(
+        &#34;killing all user processes succeeded&#34; if not failed_processes else &#34;couldn&#39;t kill all user processes!&#34;
+    )
+
+    # making sure
+    if failed_processes:
+        gone, failed_processes = psutil.wait_procs(failed_processes, timeout=0)
+
+    j.logger.debug(f&#34;stay alive: {len(failed_processes)}, pids -&gt; {[p.pid for p in failed_processes]}&#34;)
+    return failed_processes or None  # return None if the failed list is empty
 
 
-def check_running(process, min=1):
-    &#34;&#34;&#34;Checks if a process is running
+def get_similar_processes(target_proc=None):
+    &#34;&#34;&#34;Gets similar processes to current process, started with same command line and same options.
 
-    Arguments:
-        process {str} -- process name to be checked
+    Args:
+        target_proc (int or psutil.Process, optional): pid, or psutil.Process object,\
+             if None then pid for current process will be used. Defaults to None.
+    Returns:
+        list[psutil.Process] -- list of similar process
+    &#34;&#34;&#34;
+    try:
+        if target_proc is None:
+            target_proc = get_my_process()
+        elif isinstance(target_proc, int):
+            target_proc = get_process_object(target_proc)
+        for proc in psutil.process_iter([&#34;name&#34;, &#34;cmdline&#34;]):
+            if proc.info[&#34;cmdline&#34;] and target_proc.cmdline() and proc.info[&#34;cmdline&#34;] == target_proc.cmdline():
+                yield proc
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        pass
 
-    Keyword Arguments:
-        min (int) -- min number of instances required to be running (default: {1})
+
+def check_running(process_name, min=1):
+    &#34;&#34;&#34;Check if there are a specific number of running processes that match the given name.
+
+    Function will check string against Process.name(), Process.exe() and Process.cmdline().
+
+    Args:
+        process_name (str): the target process name
+        min (int, optional): min number of instances required to be running. Defaults to 1.
 
     Returns:
-        [bool] -- true if process is running
+        bool: true if process is running, otherwise False
     &#34;&#34;&#34;
-    if j.data.platform.is_linux():
-        pids = get_pids(process)
-        if len(pids) &gt;= min:
-            return True
-        return False
+    pids = get_pids(process_name, limit=min)
+    return len(pids) == min
 
 
 def check_process_for_pid(pid, process_name):
     &#34;&#34;&#34;Check whether a given pid actually does belong to a given process name.
 
-    Arguments:
-        pid (int) -- process pid
-        process {str} -- process name
+    Args:
+        pid (int): Process ID
+        process (str): String to match againset candidate processes name using equality operator
 
     Returns:
-        [bool] -- True if process_name matched process name of the pid
-    &#34;&#34;&#34;
-    pid = int(pid)
-    proc = psutil.Process(pid)
-    return proc.name() == process_name
-
-
-def set_env_var(varnames, varvalues):
-    &#34;&#34;&#34;Set the value of the environment variables C{varnames}. Existing variable are overwritten
-
-    Arguments:
-        varnames {list(str)} --  A list of the names of all the environment variables to set
-        varvalues {list(str)} -- A list of all values for the environment variables
-
+        bool: True if process_name matched process name of the pid, False otherwise.
     &#34;&#34;&#34;
     try:
-        for i in range(len(varnames)):
-            os.environ[varnames[i]] = str(varvalues[i]).strip()
+        proc = psutil.Process(pid)
+        return proc.name() == process_name
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        return False
+
+
+def set_env_var(var_names, var_values):
+    &#34;&#34;&#34;Set the value of the environment variables {varnames}. Existing variable are overwritten
+
+    Args:
+        var_names list[str]: A list of the names of all the environment variables to set
+        varvalues list[str]: A list of all values for the environment variables
+    Raises:
+        j.exceptions.RuntimeError: if error happened during setting the environment variables
+    &#34;&#34;&#34;
+    try:
+        for i in range(len(var_names)):
+            os.environ[var_names[i]] = str(var_values[i]).strip()
     except Exception as e:
         raise j.exceptions.RuntimeError(e)
 
 
-def get_pid_by_port(port):
-    &#34;&#34;&#34;Returns pids of the process that is listening on the given port
-
-    Arguments:
-        port (int) -- port number
-
-    Returns:
-        int -- pid of process that listen on that port
-    &#34;&#34;&#34;
-
-    process = get_process_by_port(port)
-    if process is None:
-        return []
-    return process.pid
-
-
-def kill_process_by_name(name, sig=signal.SIGTERM.value, match_predicate=None):
-    &#34;&#34;&#34;Kill all processes for a given command
-
-    Arguments:
-        name {str} -- Name of the command that started the process(s)
-
-    Keyword Arguments:
-        sig {bool} -- os signal to send to the process(s) (default: {signal.SIGTERM.value})
-        match_predicate {callable} -- function that does matching between
-            found processes and the targested process, the function should accept
-            two arguments and return a boolean (default: {None})
-    &#34;&#34;&#34;
-
-    pids = get_pids(name, match_predicate=match_predicate)
-    for pid in pids:
-        kill(pid, sig)
-
-
-def kill_process_by_port(port):
-    &#34;&#34;&#34;Kill process by port
-
-    Arguments:
-        port (int) -- port number
-    &#34;&#34;&#34;
-    port = int(port)
-    pid = get_pid_by_port(port)
-    if pid:
-        return kill(pid)
-
-
-def is_port_listening(port):
-    &#34;&#34;&#34;check if the port is being used by any process
+def get_pid_by_port(port, ipv6=False, udp=False):
+    &#34;&#34;&#34;Returns the PID of the process that is listening on the given port
 
     Args:
-        port (int): port number
+        port (int): Port number to lookup for.
+        ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
+        udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
 
     Returns:
-        Bool: True if port is used else False
+        (int/None): Process ID that listen on that port
     &#34;&#34;&#34;
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        result = s.connect_ex((&#34;127.0.0.1&#34;, port))
-    return result == 0
+
+    process = get_process_by_port(port, ipv6=ipv6, udp=udp)
+    if process:
+        return process.pid
 
 
-def get_process_by_port(port):
-    &#34;&#34;&#34;Returns the full name of the process that is listening on the given port
+def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None, timeout=5, sure_kill=False):
+    &#34;&#34;&#34;Kill all processes that match &#39;process_name&#39;.
 
-    Arguments:
-        port (int) -- the port for which to find the command
+    Args:
+        process_name (str): The target process name.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL
+        match_predicate (callable, optional): Function that does matching between\
+            found processes and the targeted process, the function should accept\
+            two arguments and return a boolean. Defaults to None.
+
+    Returns:
+        None or list[int] represents the IDs of the processes remaning alive.
+    &#34;&#34;&#34;
+    pids = get_pids(process_name, match_predicate=match_predicate)
+    failed_processes = []
+    for pid in pids:
+        try:
+            kill(pid, sig, timeout=timeout, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission) as e:
+            failed_processes.append(pid)
+    return failed_processes or None  # return None if the failed list is empty
+
+
+def kill_process_by_port(port, ipv6=False, udp=False, sig=signal.SIGTERM, timeout=5, sure_kill=False):
+    &#34;&#34;&#34;Kill process by port.
+
+    Args:
+        port (int): The port number.
+        ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
+        udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
+
+    Returns:
+        None
+    &#34;&#34;&#34;
+    proc = get_process_by_port(port, ipv6=ipv6, udp=udp)
+    return kill(proc, sig=sig, timeout=timeout, sure_kill=sure_kill)
+
+
+def is_port_listening(port, ipv6=False):
+    &#34;&#34;&#34;Check if the TCP port is being used by any process
+
+    Args:
+        port (int): Port number
+        ipv6 (bool, optional): Whether to ipv6 localhost address instead of ipv4 localhost address. Defaults to False.
+
+    Returns:
+        bool: True if port is used, False otherwise.
+    &#34;&#34;&#34;
+    # XXX only support ipv4, also it apparently used to pick a free port, any way using nettools is preferred
+    from jumpscale.sals import nettools
+
+    ip6 = &#34;::&#34;
+    ip4 = &#34;0.0.0.0&#34;
+    return nettools.tcp_connection_test(ip6 if ipv6 else ip4, port, timeout=5)
+
+
+def get_process_by_port(port, ipv6=False, udp=False):
+    &#34;&#34;&#34;Returns the psutil.Process object that is listening on the given port.
+
+    Args:
+        port (int): The port for which to find the process.
+        ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
+        udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
 
     Raises:
-        Runtime Error if the process is not accessible by the user
+        j.exceptions.Runtime: if the process is not accessible by the user, or no longer exists
 
     Returns:
-        [psutil.Process] -- process object
-        None -- No process found
+        psutil.Process: process object if found, otherwise None
     &#34;&#34;&#34;
-    pcons = [proc for proc in psutil.net_connections() if proc.laddr.port == port and proc.status == &#34;LISTEN&#34;]
-    if pcons:
-        pid = pcons[0].pid
-        if not pid:
-            raise j.exceptions.Runtime(&#34;No pid found maybe permission denied on the process&#34;)
-        return psutil.Process(pid)
+    for conn in psutil.net_connections():  # TODO use kind parameter
+        try:
+            # XXX should we check against ESTABLISHED status?
+            # connection.status For UDP and UNIX sockets this is always going to be psutil.CONN_NONE
+            if (
+                conn.laddr.port == port
+                and conn.status in [&#34;LISTEN&#34;, &#34;NONE&#34;, &#34;ESTABLISHED&#34;]
+                and (conn.family.name == &#34;AF_INET6&#34;) == ipv6
+                and (conn.type.name == &#34;SOCK_DGRAM&#34;) == udp
+            ):
+                if conn.pid:
+                    return psutil.Process(conn.pid)
+                else:
+                    raise j.exceptions.Runtime(&#34;pid is not retrievable, root is needed?&#34;)
+        except psutil.NoSuchProcess:
+            raise j.exceptions.Runtime(&#34;Process is no longer exists&#34;)
+        except psutil.AccessDenied:
+            raise j.exceptions.Runtime(&#34;Permission denied&#34;)
 
 
 def get_defunct_processes():
-    &#34;&#34;&#34;Gets defunc processes
+    &#34;&#34;&#34;Gets defunct (zombie) processes.
 
     Returns:
-        [list(int)] -- list of processes pids
+        list[int]: List of processes ID(s).
     &#34;&#34;&#34;
-    _, out, _ = execute(&#34;ps ax&#34;)
-    llist = []
-    for line in out.split(&#34;\n&#34;):
-        if line.strip() == &#34;&#34;:
-            continue
-        if line.find(&#34;&lt;defunct&gt;&#34;) != -1:
-            # print &#34;defunct:%s&#34;%line
-            line = line.strip()
-            pid = line.split(&#34; &#34;, 1)[0]
-            pid = int(pid.strip())
-            llist.append(pid)
-
-    return llist
+    zombie_pids = []
+    for proc in psutil.process_iter():
+        try:
+            if proc.status() == psutil.STATUS_ZOMBIE:
+                zombie_pids.append(proc.pid)
+        except (psutil.AccessDenied, psutil.NoSuchProcess):
+            pass
+    return zombie_pids
 
 
 def get_processes():
-    &#34;&#34;&#34;
-    get an interator for all running processes
+    &#34;&#34;&#34;Get an interator for all running processes
 
     Yields:
-        generator: for all processes
+        psutil.Process: for all processes running
     &#34;&#34;&#34;
     yield from psutil.process_iter()
 
 
-def get_processes_info():
-    &#34;&#34;&#34;
-    Get information for top 25 running processes sorted by memory usage
+def get_processes_info(user=None, sort=&#34;mem&#34;, filterstr=None, limit=25, desc=True):
+    &#34;&#34;&#34;Get information for top running processes sorted by memory usage or CPU usage.
+
+    Args:
+        user ([type], optional): filter the processes by username. Defaults to None.
+        sort (str, optional): sort processes by resource usage, Defaults to &#39;mem&#39;.
+            available option:
+                &#39;rss&#39; and its alias &#39;mem&#39;: sort by processes which consumed the most memory (Resident Set Size).
+                &#39;cpu_times&#39; and its alias &#39;cpu_time&#39;: sort by processes which consumed the most CPU time.
+                &#39;cpu_num&#39;: sort by the CPU number this process is currently running on.
+                &#39;cpu_percent&#39;: sort by a float representing the process CPU utilization as a percentage which can also\
+                    be &gt; 100.0 in case of a process running multiple threads on different CPUs.
+                &#39;memory_percent&#39;: sort py the process memory utilization, the process memory to total physical system memory as a percentage
+                &#39;create_time&#39;: the process creation time as a floating point number expressed in seconds since the epoch.
+                &#39;gids&#39; and its alias &#39;egid&#39;: the effective group id of this process
+                &#39;uids&#39; and its alias &#39;euid&#39;: the effective user id of this process
+                &#39;pid&#39;: sort by the process PID.
+                &#39;ppid&#39;: sort by the process parent PID
+                &#39;name&#39;: sort by the processes name
+                &#39;username&#39;: sort by the name of the user that owns the process.
+                &#39;status&#39;: sort by the current process status, one of the psutil.STATUS_* constants
+        filterstr (str, optional): the string to match against process name or command used and filter the results based on.
+        limit (int, optional): limit the results to specific number of processes, to disable set it to -1. Defaults to 25.
+        desc (bool, optional): whether to sort the data returned in descending order or not. Defaults to True.
 
     Returns:
-        [list(dict)] -- list of processes info
+        dict: processes info as a dictionary
+            available keys [
+                    &#34;cpu_num&#34;,
+                    &#34;cpu_percent&#34;,
+                    &#34;cpu_times&#34;,
+                    &#34;create_time&#34;,
+                    &#34;gids&#34;,
+                    &#34;memory_percent&#34;,
+                    &#34;name&#34;,
+                    &#34;pid&#34;,
+                    &#34;ppid&#34;,
+                    &#34;status&#34;,
+                    &#34;uids&#34;,
+                    &#34;username&#34;,
+                    &#34;rss&#34;,
+                    &#34;cpu_time&#34;,
+                    &#34;ports&#34;
+                ]
     &#34;&#34;&#34;
+
+    def _get_sort_key(procObj):
+        if sort == &#34;mem&#34;:
+            return procObj[&#34;rss&#34;]
+        if sort == &#34;cpu_times&#34;:
+            return procObj[&#34;cpu_time&#34;]
+        elif sort in [&#34;gids&#34;, &#34;egid&#34;]:
+            return procObj[&#34;gids&#34;].effective
+        elif sort in [&#34;uids&#34;, &#34;euid&#34;]:
+            return procObj[&#34;uids&#34;].effective
+        else:
+            try:
+                return procObj[sort]
+            except KeyError as e:
+                j.logger.error(f&#34;bad field name for sorting: {sort}&#34;)
+                raise j.exceptions.Value(f&#34;bad field name for sorting: {sort}&#34;)
+
     processes_list = []
-    for proc in get_processes():
+    j.logger.debug(f&#34;Args used: user={user}, sort={sort}, filterstr={filterstr}, limit={limit}, desc={desc}&#34;)
+    if not filterstr:
+        p_source = get_processes() if not user else get_user_processes(user=user)
+    else:
+        # XXX it makes sense that get_pids func should returns list of psutil.Process objects instead of list of pids
+        p_source = (
+            map(get_process_object, get_pids(process_name=filterstr))
+            if not user
+            else map(get_process_object, get_pids(process_name=filterstr, _alt_source=get_user_processes(user)))
+        )
+    for proc in p_source:
         try:
             # Fetch process details as dict
-            pinfo = proc.as_dict(attrs=[&#34;pid&#34;, &#34;name&#34;, &#34;username&#34;])
-            pinfo[&#34;rss&#34;] = proc.memory_info().rss / (1024 * 1024)
+            pinfo = proc.as_dict(
+                attrs=[
+                    &#34;cpu_num&#34;,
+                    &#34;cpu_percent&#34;,
+                    &#34;cpu_times&#34;,
+                    &#34;create_time&#34;,
+                    &#34;gids&#34;,
+                    &#34;memory_percent&#34;,
+                    &#34;name&#34;,
+                    &#34;pid&#34;,
+                    &#34;ppid&#34;,
+                    &#34;status&#34;,
+                    &#34;uids&#34;,
+                    &#34;username&#34;,
+                ]
+            )
+            pinfo[&#34;rss&#34;] = proc.memory_info().rss / (
+                1024 * 1024
+            )  # the non-swapped physical memory a process has used in Mb
+            pinfo[&#34;cpu_time&#34;] = sum(pinfo[&#34;cpu_times&#34;][:2])  # cumulative, excluding children and iowait
             pinfo[&#34;ports&#34;] = []
-            try:
-                connections = proc.connections()
-            except psutil.Error:
-                continue
+            connections = proc.connections()  # need root
             if connections:
                 for conn in connections:
                     pinfo[&#34;ports&#34;].append({&#34;port&#34;: conn.laddr.port, &#34;status&#34;: conn.status})
             # Append dict to list
             processes_list.append(pinfo)
-        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as e:
+            j.logger.debug(
+                &#34;ignoring and logging an exception that occurred while iterating over system processes, not root?&#34;
+            )
+            # j.logger.exception(&#39;an exception occurred while iterating over system processes&#39;, exception=e)
             pass
-    processes_list = sorted(processes_list, key=lambda procObj: procObj[&#34;rss&#34;], reverse=True)
-    return processes_list[:25]
+    j.logger.debug(f&#34;Processes found: {len(processes_list)}&#34;)
+    # sort the processes list by sort_key
+    sorted_processes = sorted(processes_list, key=_get_sort_key, reverse=desc)[:limit]
+    return sorted_processes
 
 
 def get_ports_mapping(status=psutil.CONN_LISTEN):
-    &#34;&#34;&#34;
-    get a mapping for process to ports with a status filter
+    &#34;&#34;&#34;Get a mapping for process to ports with a status filter
 
-    it will skip any process in case of errors (e.g. permission error)
+    It will skip any process in case of errors (e.g. permission error)
 
-    example:
-
-    ```python
-    j.sals.process.get_ports_mapping(psutil.CONN_ESTABLISHED)
-    ```
-
-    or
-
-    ```
-    j.sals.process.get_ports_mapping(&#34;ESTABLISHED&#34;)
-    ```
+    Example:
+        &gt;&gt;&gt; from jumpscale.loader import j
+        &gt;&gt;&gt; import psutil
+        &gt;&gt;&gt; j.sals.process.get_ports_mapping(psutil.CONN_ESTABLISHED)
+        &gt;&gt;&gt; # or
+        &gt;&gt;&gt; j.sals.process.get_ports_mapping(&#34;ESTABLISHED&#34;)
 
     Args:
         status (psutil.CONN_CONSTANT): `psutil` CONN_* constant as a filter. Defaults to psutil.CONN_LISTEN.
@@ -743,15 +925,20 @@ def get_ports_mapping(status=psutil.CONN_LISTEN):
 
 
 def get_memory_usage():
-    &#34;&#34;&#34;
-    Get memory status
+    &#34;&#34;&#34;Get memory status
 
     Returns:
-        dict -- memory status info
+        dict: Memory status info, available keys (&#39;total&#39;, &#39;used&#39;, &#39;percent&#39;)
+            &#39;total&#39;: total physical memory in Gb (exclusive swap).
+            &#39;used&#39;: memory used in Gb, calculated differently depending on the platform and designed for informational purposes only.
+                total - free does not necessarily match used.
+            &#39;percent&#39;: the percentage of used memory.
     &#34;&#34;&#34;
     memory_usage = {}
     memory_data = dict(psutil.virtual_memory()._asdict())
-    memory_usage[&#34;total&#34;] = math.ceil(memory_data.get(&#34;total&#34;) / (1024 * 1024 * 1024))
+    memory_usage[&#34;total&#34;] = math.ceil(
+        memory_data.get(&#34;total&#34;) / (1024 * 1024 * 1024)
+    )  # total physical memory (exclusive swap).
     memory_usage[&#34;used&#34;] = math.ceil(memory_data.get(&#34;used&#34;) / (1024 * 1024 * 1024))
     memory_usage[&#34;percent&#34;] = memory_data.get(&#34;percent&#34;)
     return memory_usage
@@ -760,33 +947,80 @@ def get_memory_usage():
 def get_environ(pid):
     &#34;&#34;&#34;Gets env vars for a specific process based on pid
 
-    Arguments:
-        pid (int) -- process pid
+    Args:
+        pid (int): process pid
+
+    Raises:
+        psutil.NoSuchProcess: if process with the given PID is not found and die set to True
+        psutil.AccessDenied: if permission denied
 
     Returns:
-        [dict] -- dict of env variables
+        dict: dict of env variables
     &#34;&#34;&#34;
-    pid = int(pid)
-    return psutil.Process(pid).environ()
+    proc = get_process_object(pid)
+    try:
+        return proc.environ()
+    except (psutil.AccessDenied, psutil.NoSuchProcess) as e:
+        raise e
+
+
+def kill_proc_tree(
+    parent, sig=signal.SIGTERM, include_parent=True, include_grand_children=True, timeout=5, sure_kill=False
+):
+    &#34;&#34;&#34;Kill a process and its children (including grandchildren) with signal `sig`
+
+    Args:
+        proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        include_parent (): Whether to kill the process itself. Defaults to True.
+        include_grand_children (): whether to kill recursively all grandchildren. Defaults to True.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
+
+    Returns:
+        (list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.
+    &#34;&#34;&#34;
+    if isinstance(parent, int):
+        try:
+            parent = get_process_object(parent)
+        except (psutil.AccessDenied, psutil.NoSuchProcess):
+            return
+
+    assert parent.pid != os.getpid(), &#34;won&#39;t kill myself&#34;
+
+    processes = parent.children(recursive=include_grand_children)[::-1]
+    failed = []
+    if include_parent:
+        processes.append(parent)
+
+    for p in processes:
+        try:
+            kill(p, sig=sig, timeout=timeout, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission):
+            failed.append(p)
+
+    # making sure
+    if failed:
+        gone, failed = psutil.wait_procs(failed, timeout=0)
+    return failed or None
 
 
 def in_docker():
-    &#34;&#34;&#34;will check if we are in a docker
+    &#34;&#34;&#34;will check if we are in a docker.
 
     Returns:
-        Bool: True if in docker - False if not
+        bool: True if in docker. False otherwise.
     &#34;&#34;&#34;
     rc, out, _ = j.sals.process.execute(&#34;cat /proc/1/cgroup&#34;, die=False, showout=False)
-    if rc == 0 and &#34;/docker/&#34; in out:
-        return True
-    return False
+    return rc == 0 and &#34;/docker/&#34; in out
 
 
 def in_host():
-    &#34;&#34;&#34;will check if we are in a host
+    &#34;&#34;&#34;Will check if we are in a host.
 
     Returns:
-        Bool: True if in host - False if not
+        bool: True if in host. False otherwise.
     &#34;&#34;&#34;
     return not in_docker()</code></pre>
 </details>
@@ -803,179 +1037,246 @@ def in_host():
 </code></dt>
 <dd>
 <section class="desc"><p>Check whether a given pid actually does belong to a given process name.</p>
-<h2 id="arguments">Arguments</h2>
-<p>pid (int) &ndash; process pid
-process {str} &ndash; process name</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>pid</code></strong> :&ensp;<code>int</code></dt>
+<dd>Process ID</dd>
+<dt><strong><code>process</code></strong> :&ensp;<code>str</code></dt>
+<dd>String to match againset candidate processes name using equality operator</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[bool] &ndash; True if process_name matched process name of the pid</p></section>
+<dl>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if process_name matched process name of the pid, False otherwise.</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def check_process_for_pid(pid, process_name):
     &#34;&#34;&#34;Check whether a given pid actually does belong to a given process name.
 
-    Arguments:
-        pid (int) -- process pid
-        process {str} -- process name
+    Args:
+        pid (int): Process ID
+        process (str): String to match againset candidate processes name using equality operator
 
     Returns:
-        [bool] -- True if process_name matched process name of the pid
+        bool: True if process_name matched process name of the pid, False otherwise.
     &#34;&#34;&#34;
-    pid = int(pid)
-    proc = psutil.Process(pid)
-    return proc.name() == process_name</code></pre>
-</details>
-</dd>
-<dt id="jumpscale.sals.process.check_running"><code class="name flex">
-<span>def <span class="ident">check_running</span></span>(<span>process, min=1)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Checks if a process is running</p>
-<h2 id="arguments">Arguments</h2>
-<p>process {str} &ndash; process name to be checked
-Keyword Arguments:
-min (int) &ndash; min number of instances required to be running (default: {1})</p>
-<h2 id="returns">Returns</h2>
-<p>[bool] &ndash; true if process is running</p></section>
-<details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def check_running(process, min=1):
-    &#34;&#34;&#34;Checks if a process is running
-
-    Arguments:
-        process {str} -- process name to be checked
-
-    Keyword Arguments:
-        min (int) -- min number of instances required to be running (default: {1})
-
-    Returns:
-        [bool] -- true if process is running
-    &#34;&#34;&#34;
-    if j.data.platform.is_linux():
-        pids = get_pids(process)
-        if len(pids) &gt;= min:
-            return True
+    try:
+        proc = psutil.Process(pid)
+        return proc.name() == process_name
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
         return False</code></pre>
 </details>
 </dd>
-<dt id="jumpscale.sals.process.check_start"><code class="name flex">
-<span>def <span class="ident">check_start</span></span>(<span>cmd, filterstr, nrinstances=1, retry=1)</span>
+<dt id="jumpscale.sals.process.check_running"><code class="name flex">
+<span>def <span class="ident">check_running</span></span>(<span>process_name, min=1)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Run command and check if it is started based on filterstr</p>
-<h2 id="arguments">Arguments</h2>
-<p>cmd {str} &ndash; command to be executed
-filterstr {str} &ndash; filter string
-Keyword Arguments:
-instances (int) &ndash; number of needed instances (default: {1})
-retry (int) &ndash; number of retries (default: {1})</p>
-<h2 id="raises">Raises</h2>
+<section class="desc"><p>Check if there are a specific number of running processes that match the given name.</p>
+<p>Function will check string against Process.name(), Process.exe() and Process.cmdline().</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><code>j.exceptions.RuntimeError</code>: <code>will</code> <code>be</code> <code>raised</code> <code>if</code> <code>we</code> <code>didn't</code> <code>reach</code> <code>number</code> of <code>required</code> <code>instances</code></dt>
-<dd>&nbsp;</dd>
+<dt><strong><code>process_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>the target process name</dd>
+<dt><strong><code>min</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>min number of instances required to be running. Defaults to 1.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>bool</code></strong></dt>
+<dd>true if process is running, otherwise False</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def check_start(cmd, filterstr, nrinstances=1, retry=1):
-    &#34;&#34;&#34;Run command and check if it is started based on filterstr
+<pre><code class="python">def check_running(process_name, min=1):
+    &#34;&#34;&#34;Check if there are a specific number of running processes that match the given name.
 
-    Arguments:
-        cmd {str} -- command to be executed
-        filterstr {str} -- filter string
+    Function will check string against Process.name(), Process.exe() and Process.cmdline().
 
-    Keyword Arguments:
-        instances (int) -- number of needed instances (default: {1})
-        retry (int) -- number of retries (default: {1})
+    Args:
+        process_name (str): the target process name
+        min (int, optional): min number of instances required to be running. Defaults to 1.
+
+    Returns:
+        bool: true if process is running, otherwise False
+    &#34;&#34;&#34;
+    pids = get_pids(process_name, limit=min)
+    return len(pids) == min</code></pre>
+</details>
+</dd>
+<dt id="jumpscale.sals.process.check_start"><code class="name flex">
+<span>def <span class="ident">check_start</span></span>(<span>cmd, filterstr, n_instances=1, retry=1)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Run command (possibly multiple times) and check if it is started based on filterstr</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt>cmd (str/list): Command to be executed.</dt>
+<dt><strong><code>filterstr</code></strong> :&ensp;<code>str</code></dt>
+<dd>Filter string. will match against against Process.name(),
+Process.exe() and Process.cmdline()</dd>
+<dt><strong><code>n_instances</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Number of needed instances. Defaults to 1.</dd>
+<dt><strong><code>retry</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Number of retries to execute the command and check. Defaults to 1.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<p>j.exceptions.Runtime: will be raised if we didn't reach number of required instances.</p></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def check_start(cmd, filterstr, n_instances=1, retry=1):
+    &#34;&#34;&#34;Run command (possibly multiple times) and check if it is started based on filterstr
+
+    Args:
+        cmd (str/list): Command to be executed.
+        filterstr (str): Filter string. will match against against Process.name(),\
+            Process.exe() and Process.cmdline()
+        n_instances (int, optional): Number of needed instances. Defaults to 1.
+        retry (int, optional): Number of retries to execute the command and check. Defaults to 1.
 
     Raises:
-        j.exceptions.RuntimeError: will be raised if we didn&#39;t reach number of required instances
+        j.exceptions.Runtime: will be raised if we didn&#39;t reach number of required instances.
     &#34;&#34;&#34;
-    found = get_filtered_pids(filterstr)
     for i in range(retry):
-        if len(found) == nrinstances:
-            return
-        # print &#34;START:%s&#34;%cmd
-        execute(cmd)
-        time.sleep(1)
-    found = get_filtered_pids(filterstr)
-    if len(found) != nrinstances:
-        raise j.exceptions.RuntimeError(
-            &#34;could not start %s, found %s nr of instances. Needed %s.&#34; % (cmd, len(found), nrinstances)
-        )</code></pre>
+        if isinstance(cmd, str):
+            cmd = cmd.split()
+        proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        j.logger.debug(f&#34;attempt no: {i}&#34;)
+        j.logger.debug(f&#34;executed cmd: {cmd}&#34;)
+        j.logger.debug(f&#34;proc.cmdline: {proc.cmdline()}&#34;)
+        j.logger.debug(f&#34;pid: {proc.pid}&#34;)
+        j.logger.debug(f&#34;status: {proc.status()}&#34;)
+        j.logger.debug(f&#34;name: {proc.name()}&#34;)
+        j.logger.debug(f&#34;exe: {proc.exe()}&#34;)
+        j.logger.debug(f&#34;children: {proc.children(recursive=True)}&#34;)
+        j.logger.debug(f&#34;parents: {proc.parents()}&#34;)
+        try:
+            rc = proc.wait(timeout=1)  # makesure the process is stable
+            if rc == 0:  # executing the command succeeded but exited immediately!
+                j.logger.debug(&#34;executing the start command succeeded but exited immediately&#34;)
+            else:
+                j.logger.debug(&#34;the start command exited with error&#34;)  # the process exited with error
+            j.logger.debug(f&#34;return code is: {rc}&#34;)
+        except psutil.TimeoutExpired:
+            j.logger.debug(&#34;the start command still running after 1 sec&#34;)  # still running
+        # TODO check based on command
+        if check_running(filterstr, min=n_instances):
+            j.logger.debug(f&#34;found at least {n_instances} instances using the filter string: {filterstr}&#34;)
+            return True  # XXX should remove? None
+        else:
+            j.logger.debug(f&#34;the required number of instances using the filter string: {filterstr} not found yet!&#34;)
+            continue
+    j.logger.error(f&#34;could not start the required number of instances ({n_instances}) after {i} attempts.&#34;)
+    raise j.exceptions.Runtime(&#34;could not start the required number of instances.&#34;)</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.check_stop"><code class="name flex">
-<span>def <span class="ident">check_stop</span></span>(<span>cmd, filterstr, retry=1, nrinstances=0)</span>
+<span>def <span class="ident">check_stop</span></span>(<span>cmd, filterstr, retry=1, n_instances=0)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Executes a stop command and check if it is already stopped based on filterstr</p>
-<h2 id="arguments">Arguments</h2>
-<p>cmd {str} &ndash; command to be executed
-filterstr {str} &ndash; filter string
-Keyword Arguments:
-retry (int) &ndash; number of retries (default: {1})
-nrinstances (int) &ndash; number of instances after stop (default: {0})</p>
+<section class="desc"><p>Executes a stop command (possibly multiple times) and check if it is already stopped based on filterstr</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>cmd</code></strong> :&ensp;<code>str</code></dt>
+<dd>Command to be executed.</dd>
+<dt><strong><code>filterstr</code></strong> :&ensp;<code>str</code></dt>
+<dd>Filter string.</dd>
+<dt><strong><code>retry</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Number of retries. Defaults to 1.</dd>
+<dt><strong><code>n_inst</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Number of instances after stop. Defaults to 0.</dd>
+</dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><code>j.exceptions.RuntimeError</code>: <code>if</code> <code>nr</code> of <code>instances</code> <code>not</code> <code>matched</code></dt>
+<dt><code>j.exceptions.Runtime</code>: <code>if</code> <code>number</code> of <code>instances</code> <code>not</code> <code>matched</code></dt>
 <dd>&nbsp;</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def check_stop(cmd, filterstr, retry=1, nrinstances=0):
-    &#34;&#34;&#34;Executes a stop command and check if it is already stopped based on filterstr
+<pre><code class="python">def check_stop(cmd, filterstr, retry=1, n_instances=0):
+    &#34;&#34;&#34;Executes a stop command (possibly multiple times) and check if it is already stopped based on filterstr
 
-    Arguments:
-        cmd {str} -- command to be executed
-        filterstr {str} -- filter string
-
-    Keyword Arguments:
-        retry (int) -- number of retries (default: {1})
-        nrinstances (int) -- number of instances after stop (default: {0})
+    Args:
+        cmd (str): Command to be executed.
+        filterstr (str): Filter string.
+        retry (int, optional): Number of retries. Defaults to 1.
+        n_inst (int, optional): Number of instances after stop. Defaults to 0.
 
     Raises:
-        j.exceptions.RuntimeError: if nr of instances not matched
+        j.exceptions.Runtime: if number of instances not matched
     &#34;&#34;&#34;
 
-    found = get_filtered_pids(filterstr)
     for i in range(retry):
-        if len(found) == nrinstances:
-            return
-        # print &#34;START:%s&#34;%cmd
-        execute(cmd, die=False)
-        time.sleep(1)
-        found = get_filtered_pids(filterstr)
-        for item in found:
-            kill(int(item), 9)
-        found = get_filtered_pids(filterstr)
-
-    if len(found) != 0:
-        raise j.exceptions.RuntimeError(&#34;could not stop %s, found %s nr of instances.&#34; % (cmd, len(found)))</code></pre>
+        if isinstance(cmd, str):
+            cmd = cmd.split()
+        proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        j.logger.debug(f&#34;attempt no: {i}&#34;)
+        j.logger.debug(f&#34;executed cmd: {cmd}&#34;)
+        j.logger.debug(f&#34;proc.cmdline: {proc.cmdline()}&#34;)
+        j.logger.debug(f&#34;pid: {proc.pid}&#34;)
+        j.logger.debug(f&#34;status: {proc.status()}&#34;)
+        j.logger.debug(f&#34;name: {proc.name()}&#34;)
+        j.logger.debug(f&#34;exe: {proc.exe()}&#34;)
+        j.logger.debug(f&#34;children: {proc.children(recursive=True)}&#34;)
+        j.logger.debug(f&#34;parents: {proc.parents()}&#34;)
+        try:
+            rc = proc.wait(timeout=5)  # makesure the process is stable
+            # print(f&#39;rc: {rc}&#39;)
+            if rc == 0:
+                # executing the process succeeded but exited immediately!
+                j.logger.debug(&#34;executing the stop command succeeded but exited immediately&#34;)
+            else:
+                # the process exited with error
+                j.logger.debug(&#34;the stop command exited with error&#34;)  # the process exited with error
+        except psutil.TimeoutExpired:
+            j.logger.debug(&#34;the start command still running after 1 sec&#34;)  # still running
+        found = get_pids(filterstr)
+        if len(found) == n_instances:
+            j.logger.debug(
+                f&#34;the required {n_instances} matching the instances found using the filter string: {filterstr}&#34;
+            )
+            return True  # should remove? None
+        else:
+            j.logger.debug(
+                f&#34;the required {n_instances} not matching the instances number found using the filter string: {filterstr} yet&#34;
+            )
+            continue
+    j.logger.error(f&#34;could not match the required number of instances ({n_instances}) after {i} attempts.&#34;)
+    j.logger.debug(f&#34;alive: {found}&#34;)
+    j.logger.debug(f&#34;{len(found)}&#34;)
+    raise j.exceptions.Runtime(f&#34;could not stop {cmd}, found {len(found)} of instances instead of {n_instances}&#34;)</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.execute"><code class="name flex">
 <span>def <span class="ident">execute</span></span>(<span>cmd, showout=False, cwd=None, shell=&#39;/bin/bash&#39;, timeout=600, asynchronous=False, env=None, replace_env=False, die=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>execute a command.</p>
-<p>accepts command as a list too, with auto-escaping.</p>
-<h2 id="arguments">Arguments</h2>
+<section class="desc"><p>Execute a command.</p>
+<p>Accepts command as a list too, with auto-escaping.</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><strong><code>cmd</code></strong> :&ensp;<code>str</code> or <code>list</code></dt>
-<dd>command to be executed, e.g. <code>"ls -la"</code> or `["ls", "-la"]</dd>
+<dt>cmd (str/list[str]): Command to be executed, e.g. "ls -la" or ["ls", "-la"]</dt>
+<dt><strong><code>showout</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to show stdout of the command or not. Defaults to False.</dd>
+<dt><strong><code>cwd</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>Path to <code>cd</code> into before running command. Defaults to None.</dd>
+<dt><strong><code>shell</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>Specify a working directory for the command. Defaults to "/bin/bash".</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Timeout before kill the process. Defaults to 600.</dd>
+<dt><strong><code>asynchronous</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to execute in asynchronous mode or not. Defaults to False.</dd>
+<dt><strong><code>env</code></strong> :&ensp;<code>dict</code>, optional</dt>
+<dd>Add environment variables here. Defaults to None.</dd>
+<dt><strong><code>replace_env</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to replace the entire environment with env. Defaults to False.</dd>
+<dt><strong><code>die</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to raise exception if command failed or not. Defaults to False.</dd>
 </dl>
-<p>Keyword Arguments:
-showout (bool): show stdout of the command (default: False)
-cwd (str): specify a working directory for the command (default: None)
-shell (str): specify a shell to execute the command (default: "/bin/bash")
-timeout (int): timeout before kill the process (default: 600)
-asynchronous (bool): execute in asynchronous mode or not (default: False)
-env (dict): add environment variables here (default: {})
-replace_env (bool): replace entire environment with env (default: False)
-die (bool): die if command failed (default: False)</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><strong><code>tuple</code></strong></dt>
-<dd>(rc, out, err)</dd>
+<dd>tuple[return_code: int, stdout: str, stderr: str]</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
@@ -990,26 +1291,23 @@ die (bool): die if command failed (default: False)</p>
     replace_env=False,
     die=False,
 ):
-    &#34;&#34;&#34;
-    execute a command.
+    &#34;&#34;&#34;Execute a command.
 
-    accepts command as a list too, with auto-escaping.
+    Accepts command as a list too, with auto-escaping.
 
-    Arguments:
-        cmd (str or list): command to be executed, e.g. `&#34;ls -la&#34;` or `[&#34;ls&#34;, &#34;-la&#34;]
-
-    Keyword Arguments:
-        showout (bool): show stdout of the command (default: False)
-        cwd (str): specify a working directory for the command (default: None)
-        shell (str): specify a shell to execute the command (default: &#34;/bin/bash&#34;)
-        timeout (int): timeout before kill the process (default: 600)
-        asynchronous (bool): execute in asynchronous mode or not (default: False)
-        env (dict): add environment variables here (default: {})
-        replace_env (bool): replace entire environment with env (default: False)
-        die (bool): die if command failed (default: False)
+    Args:
+        cmd (str/list[str]): Command to be executed, e.g. &#34;ls -la&#34; or [&#34;ls&#34;, &#34;-la&#34;]
+        showout (bool, optional): Whether to show stdout of the command or not. Defaults to False.
+        cwd (str, optional): Path to `cd` into before running command. Defaults to None.
+        shell (str, optional): Specify a working directory for the command. Defaults to &#34;/bin/bash&#34;.
+        timeout (int, optional): Timeout before kill the process. Defaults to 600.
+        asynchronous (bool, optional): Whether to execute in asynchronous mode or not. Defaults to False.
+        env (dict, optional): Add environment variables here. Defaults to None.
+        replace_env (bool, optional): Whether to replace the entire environment with env. Defaults to False.
+        die (bool, optional): Whether to raise exception if command failed or not. Defaults to False.
 
     Returns:
-        tuple: (rc, out, err)
+        tuple: tuple[return_code: int, stdout: str, stderr: str]
     &#34;&#34;&#34;
     return j.core.executors.run_local(
         cmd=cmd,
@@ -1028,30 +1326,25 @@ die (bool): die if command failed (default: False)</p>
 <span>def <span class="ident">get_defunct_processes</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets defunc processes</p>
+<section class="desc"><p>Gets defunct (zombie) processes.</p>
 <h2 id="returns">Returns</h2>
-<p>[list(int)] &ndash; list of processes pids</p></section>
+<p>list[int]: List of processes ID(s).</p></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_defunct_processes():
-    &#34;&#34;&#34;Gets defunc processes
+    &#34;&#34;&#34;Gets defunct (zombie) processes.
 
     Returns:
-        [list(int)] -- list of processes pids
+        list[int]: List of processes ID(s).
     &#34;&#34;&#34;
-    _, out, _ = execute(&#34;ps ax&#34;)
-    llist = []
-    for line in out.split(&#34;\n&#34;):
-        if line.strip() == &#34;&#34;:
-            continue
-        if line.find(&#34;&lt;defunct&gt;&#34;) != -1:
-            # print &#34;defunct:%s&#34;%line
-            line = line.strip()
-            pid = line.split(&#34; &#34;, 1)[0]
-            pid = int(pid.strip())
-            llist.append(pid)
-
-    return llist</code></pre>
+    zombie_pids = []
+    for proc in psutil.process_iter():
+        try:
+            if proc.status() == psutil.STATUS_ZOMBIE:
+                zombie_pids.append(proc.pid)
+        except (psutil.AccessDenied, psutil.NoSuchProcess):
+            pass
+    return zombie_pids</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_environ"><code class="name flex">
@@ -1059,73 +1352,102 @@ die (bool): die if command failed (default: False)</p>
 </code></dt>
 <dd>
 <section class="desc"><p>Gets env vars for a specific process based on pid</p>
-<h2 id="arguments">Arguments</h2>
-<p>pid (int) &ndash; process pid</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>pid</code></strong> :&ensp;<code>int</code></dt>
+<dd>process pid</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>psutil.NoSuchProcess</code>: <code>if</code> <code>process</code> <code>with</code> <code>the</code> <code>given</code> <code>PID</code> <code>is</code> <code>not</code> <code>found</code> <code>and</code> <code>die</code> <code>set</code> <code>to</code> <code>True</code></dt>
+<dd>&nbsp;</dd>
+<dt><code>psutil.AccessDenied</code>: <code>if</code> <code>permission</code> <code>denied</code></dt>
+<dd>&nbsp;</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[dict] &ndash; dict of env variables</p></section>
+<dl>
+<dt><strong><code>dict</code></strong></dt>
+<dd>dict of env variables</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_environ(pid):
     &#34;&#34;&#34;Gets env vars for a specific process based on pid
 
-    Arguments:
-        pid (int) -- process pid
+    Args:
+        pid (int): process pid
+
+    Raises:
+        psutil.NoSuchProcess: if process with the given PID is not found and die set to True
+        psutil.AccessDenied: if permission denied
 
     Returns:
-        [dict] -- dict of env variables
+        dict: dict of env variables
     &#34;&#34;&#34;
-    pid = int(pid)
-    return psutil.Process(pid).environ()</code></pre>
+    proc = get_process_object(pid)
+    try:
+        return proc.environ()
+    except (psutil.AccessDenied, psutil.NoSuchProcess) as e:
+        raise e</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_filtered_pids"><code class="name flex">
 <span>def <span class="ident">get_filtered_pids</span></span>(<span>filterstr, excludes=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get pids filtered by filterstr and execludes</p>
-<h2 id="arguments">Arguments</h2>
-<p>filterstr {str} &ndash; filter string.
-Keyword Arguments:
-excludes {list(str)} &ndash; execlude list (default: {None})</p>
+<section class="desc"><p>Get pids filtered by filterstr and excludes</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>filterstr</code></strong> :&ensp;<code>str</code></dt>
+<dd>the String to filter based on.</dd>
+<dt><strong><code>excludes</code></strong> :&ensp;<code>list</code>[<code>str</code>]</dt>
+<dd>exclude list. Defaults to None.</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[list(int)] &ndash; pids</p></section>
+<dl>
+<dt><code>list</code>[<code>int</code>]: <code>list</code> of <code>pids</code></dt>
+<dd>&nbsp;</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_filtered_pids(filterstr, excludes=None):
-    &#34;&#34;&#34;Get pids filtered by filterstr and execludes
+    &#34;&#34;&#34;Get pids filtered by filterstr and excludes
 
-    Arguments:
-        filterstr {str} -- filter string.
-
-    Keyword Arguments:
-        excludes {list(str)} -- execlude list (default: {None})
+    Args:
+        filterstr (str): the String to filter based on.
+        excludes (list[str]): exclude list. Defaults to None.
 
     Returns:
-        [list(int)] -- pids
+        list[int]: list of pids
     &#34;&#34;&#34;
-    excludes = excludes or []
-    cmd = &#34;ps ax | grep &#39;%s&#39;&#34; % filterstr
-    rc, out, err = j.core.executors.run_local(cmd)
-    # print out
-    found = []
-
-    def checkexclude(c, excludes):
-        for item in excludes:
-            c = c.lower()
-            if c.find(item.lower()) != -1:
-                return True
-        return False
-
-    for line in out.split(&#34;\n&#34;):
-        if line.find(&#34;grep&#34;) != -1 or line.strip() == &#34;&#34;:
-            continue
-        if line.strip() != &#34;&#34;:
-            if line.find(filterstr) != -1:
-                line = line.strip()
-                if not checkexclude(line, excludes):
-                    # print &#34;found pidline:%s&#34;%line
-                    found.append(int(line.split(&#34; &#34;)[0]))
-    return found</code></pre>
+    pids = []
+    try:
+        for proc in psutil.process_iter([&#34;name&#34;, &#34;cmdline&#34;]):
+            cmd_line = &#34; &#34;.join(proc.info[&#34;cmdline&#34;])
+            if proc.info[&#34;cmdline&#34;] and filterstr in cmd_line:
+                j.logger.debug(f&#34;found filter string: {filterstr} in command line: {cmd_line}&#34;)
+                if excludes:
+                    for exclude in excludes:
+                        if exclude in cmd_line:
+                            j.logger.debug(
+                                f&#34;but excluded because it contain exclude string: {exclude} in command line: {cmd_line}&#34;
+                            )
+                            break
+                    else:  # intended `for/else` meaning for loop finished normally with no break
+                        pids.append(proc.pid)  # may yield proc instead
+                    continue
+                else:
+                    pids.append(proc.pid)  # may yield proc instead
+        j.logger.debug(
+            f&#34;founded pids are: {pids}&#34;
+            if pids
+            else f&#34;filter string {filterstr} not found in any processes. root needed?&#34;
+        )
+        return pids
+    except (psutil.AccessDenied, psutil.NoSuchProcess) as e:
+        j.logger.debug(&#34;logging and bypassing the exception occurred while iterating over the system processes&#34;)
+        j.logger.exception(&#34;exception occurred while iterating over the system processes&#34;, exception=e)
+        pass</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_memory_usage"><code class="name flex">
@@ -1135,21 +1457,30 @@ excludes {list(str)} &ndash; execlude list (default: {None})</p>
 <section class="desc"><p>Get memory status</p>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt><code>dict</code> &ndash; <code>memory</code> <code>status</code> <code>info</code></dt>
-<dd>&nbsp;</dd>
+<dt><strong><code>dict</code></strong></dt>
+<dd>Memory status info, available keys ('total', 'used', 'percent')
+'total': total physical memory in Gb (exclusive swap).
+'used': memory used in Gb, calculated differently depending on the platform and designed for informational purposes only.
+total - free does not necessarily match used.
+'percent': the percentage of used memory.</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_memory_usage():
-    &#34;&#34;&#34;
-    Get memory status
+    &#34;&#34;&#34;Get memory status
 
     Returns:
-        dict -- memory status info
+        dict: Memory status info, available keys (&#39;total&#39;, &#39;used&#39;, &#39;percent&#39;)
+            &#39;total&#39;: total physical memory in Gb (exclusive swap).
+            &#39;used&#39;: memory used in Gb, calculated differently depending on the platform and designed for informational purposes only.
+                total - free does not necessarily match used.
+            &#39;percent&#39;: the percentage of used memory.
     &#34;&#34;&#34;
     memory_usage = {}
     memory_data = dict(psutil.virtual_memory()._asdict())
-    memory_usage[&#34;total&#34;] = math.ceil(memory_data.get(&#34;total&#34;) / (1024 * 1024 * 1024))
+    memory_usage[&#34;total&#34;] = math.ceil(
+        memory_data.get(&#34;total&#34;) / (1024 * 1024 * 1024)
+    )  # total physical memory (exclusive swap).
     memory_usage[&#34;used&#34;] = math.ceil(memory_data.get(&#34;used&#34;) / (1024 * 1024 * 1024))
     memory_usage[&#34;percent&#34;] = memory_data.get(&#34;percent&#34;)
     return memory_usage</code></pre>
@@ -1159,162 +1490,160 @@ excludes {list(str)} &ndash; execlude list (default: {None})</p>
 <span>def <span class="ident">get_my_process</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>get process object of current process</p>
+<section class="desc"><p>Get psutil.Process object of the current process.</p>
 <h2 id="returns">Returns</h2>
-<p>[psutil.Process] &ndash; process object</p></section>
+<p>(psutil.Process): psutil.Process object of the current process.</p></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_my_process():
-    &#34;&#34;&#34;get process object of current process
+    &#34;&#34;&#34;Get psutil.Process object of the current process.
 
     Returns:
-        [psutil.Process] -- process object
+        (psutil.Process): psutil.Process object of the current process.
     &#34;&#34;&#34;
     return get_process_object(os.getpid())</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_pid_by_port"><code class="name flex">
-<span>def <span class="ident">get_pid_by_port</span></span>(<span>port)</span>
+<span>def <span class="ident">get_pid_by_port</span></span>(<span>port, ipv6=False, udp=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns pids of the process that is listening on the given port</p>
-<h2 id="arguments">Arguments</h2>
-<p>port (int) &ndash; port number</p>
+<section class="desc"><p>Returns the PID of the process that is listening on the given port</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>Port number to lookup for.</dd>
+<dt><strong><code>ipv6</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.</dd>
+<dt><strong><code>udp</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to search the connections for UDP port instead of TCP. Defaults to False.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>(int/None): Process ID that listen on that port</p></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def get_pid_by_port(port, ipv6=False, udp=False):
+    &#34;&#34;&#34;Returns the PID of the process that is listening on the given port
+
+    Args:
+        port (int): Port number to lookup for.
+        ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
+        udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
+
+    Returns:
+        (int/None): Process ID that listen on that port
+    &#34;&#34;&#34;
+
+    process = get_process_by_port(port, ipv6=ipv6, udp=udp)
+    if process:
+        return process.pid</code></pre>
+</details>
+</dd>
+<dt id="jumpscale.sals.process.get_pids"><code class="name flex">
+<span>def <span class="ident">get_pids</span></span>(<span>process_name, match_predicate=None, limit=0)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Return a list of processes ID(s) matching 'process_name'.</p>
+<p>Function will check string against Process.name(), Process.exe() and Process.cmdline()</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>process_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The target process name</dd>
+<dt><strong><code>match_predicate</code></strong> :&ensp;<code>callable</code>, optional</dt>
+<dd>Function that does matching between
+found processes and the targeted process, the function should accept
+two arguments and return a boolean. Defaults to None.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>If not equal to 0, function will return as fast as the number
+of PID(s) found become equal to <code>limit</code> value.</dd>
+</dl>
+<p>_alt_source(callable or iterable, optional): Can be used to specify an alternative source
+of the psutil.Process objects to match against.
+ex: get_user_processes func, or get_similar_processes.
+if not specified, psutil.process_iter will be used. Defaults to None.</p>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt><code>int</code> &ndash; <code>pid</code> of <code>process</code> <code>that</code> <code>listen</code> <code>on</code> <code>that</code> <code>port</code></dt>
+<dt><code>list</code>[<code>int</code>]: <code>list</code> of <code>PID</code>(<code>s</code>)</dt>
 <dd>&nbsp;</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def get_pid_by_port(port):
-    &#34;&#34;&#34;Returns pids of the process that is listening on the given port
+<pre><code class="python">def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
+    &#34;&#34;&#34;Return a list of processes ID(s) matching &#39;process_name&#39;.
 
-    Arguments:
-        port (int) -- port number
+    Function will check string against Process.name(), Process.exe() and Process.cmdline()
 
-    Returns:
-        int -- pid of process that listen on that port
-    &#34;&#34;&#34;
-
-    process = get_process_by_port(port)
-    if process is None:
-        return []
-    return process.pid</code></pre>
-</details>
-</dd>
-<dt id="jumpscale.sals.process.get_pids"><code class="name flex">
-<span>def <span class="ident">get_pids</span></span>(<span>process_name, match_predicate=None)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Get process ID(s) for a given process</p>
-<h2 id="arguments">Arguments</h2>
-<p>process {str} &ndash; process name
-Keyword Arguments:
-match_predicate {callable} &ndash; function that does matching between
-found processes and the targested process, the function should accept
-two arguments and return a boolean, defaults to None (default: {None})</p>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><code>j.exceptions.RuntimeError</code>: [<code>description</code>]</dt>
-<dd>&nbsp;</dd>
-<dt><code>j.exceptions.NotImplemented</code>: [<code>description</code>]</dt>
-<dd>&nbsp;</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<p>[list(int)] &ndash; list of pids</p></section>
-<details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_pids(process_name, match_predicate=None):
-    &#34;&#34;&#34;Get process ID(s) for a given process
-
-    Arguments:
-        process {str} -- process name
-
-    Keyword Arguments:
-        match_predicate {callable} -- function that does matching between
-        found processes and the targested process, the function should accept
-        two arguments and return a boolean, defaults to None (default: {None})
-
-    Raises:
-        j.exceptions.RuntimeError: [description]
-        j.exceptions.NotImplemented: [description]
+    Args:
+        process_name (str): The target process name
+        match_predicate (callable, optional): Function that does matching between\
+            found processes and the targeted process, the function should accept\
+            two arguments and return a boolean. Defaults to None.
+        limit (int, optional): If not equal to 0, function will return as fast as the number\
+            of PID(s) found become equal to `limit` value.
+        _alt_source(callable or iterable, optional): Can be used to specify an alternative source\
+            of the psutil.Process objects to match against.
+            ex: get_user_processes func, or get_similar_processes.
+            if not specified, psutil.process_iter will be used. Defaults to None.
 
     Returns:
-        [list(int)] -- list of pids
+        list[int]: list of PID(s)
     &#34;&#34;&#34;
     # default match predicate
-    # why aren&#39;t we using psutil ??
     def default_predicate(target, given):
-        return target.strip().lower() in given.lower()
+        j.logger.debug(f&#34;matching {target} with {given}&#34;)
+        if isinstance(given, list):
+            return target.strip().lower() in given
+        return target.strip().lower() == given.lower()
 
-    if match_predicate is None:
-        match_predicate = default_predicate
+    match_predicate = match_predicate or default_predicate
 
-    if process_name is None:
-        raise j.exceptions.RuntimeError(&#34;process cannot be None&#34;)
-    if j.data.platform.is_unix():
-        pids = set()
-        for process in get_processes():
-            try:
-                pid = process.pid
-                if not isinstance(pid, int):
-                    continue
-                name = process.name()
-                if match_predicate(process_name, name):
-                    pids.add(pid)
-                elif match_predicate(process_name, process.exe()):
-                    pids.add(pid)
-                else:
-                    cmdline = process.cmdline()
-                    if cmdline and cmdline[0]:
-                        if match_predicate(process_name, cmdline[0]):
-                            pids.add(pid)
-            except (psutil.Error, FileNotFoundError):
-                continue
-        return list(pids)
-    else:
-        raise j.exceptions.NotImplemented(&#34;getProcessPid is only implemented for unix&#34;)</code></pre>
+    pids = []
+    for proc in psutil.process_iter([&#34;name&#34;, &#34;exe&#34;, &#34;cmdline&#34;]):
+        try:
+            j.logger.debug(f&#34;process to check: {proc.info}&#34;)
+            if (
+                (match_predicate(process_name, proc.info[&#34;name&#34;]))
+                or (proc.info[&#34;exe&#34;] and match_predicate(process_name, os.path.basename(proc.info[&#34;exe&#34;])))
+                or (proc.info[&#34;cmdline&#34;] and match_predicate(process_name, proc.info[&#34;cmdline&#34;]))
+            ):
+                pids.append(proc.pid)
+                # return early if no need to iterate over all running process
+                if limit and len(pids) == limit:
+                    return pids
+        except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess):
+            pass
+    return pids</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_pids_filtered_by_regex"><code class="name flex">
-<span>def <span class="ident">get_pids_filtered_by_regex</span></span>(<span>regex_list, excludes=None)</span>
+<span>def <span class="ident">get_pids_filtered_by_regex</span></span>(<span>regex_list)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>get pids of a process filtered by Regex list</p>
-<h2 id="arguments">Arguments</h2>
-<p>regex_list {list(str)} &ndash; list of regex expressions
-Keyword Arguments:
-excludes {list(str)} &ndash; list of excludes (default: {None})</p>
+<section class="desc"><p>Get pids of a process filtered by Regex list</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>regex_list</code></strong> :&ensp;<code>list</code>[<code>str</code>]</dt>
+<dd>List of regex expressions.</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[list(int)] &ndash; list of pids</p></section>
+<p>list(int): List of pids.</p></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def get_pids_filtered_by_regex(regex_list, excludes=None):
-    &#34;&#34;&#34;get pids of a process filtered by Regex list
+<pre><code class="python">def get_pids_filtered_by_regex(regex_list):
+    &#34;&#34;&#34;Get pids of a process filtered by Regex list
 
-    Arguments:
-        regex_list {list(str)} -- list of regex expressions
-
-    Keyword Arguments:
-        excludes {list(str)} -- list of excludes (default: {None})
+    Args:
+        regex_list (list[str]): List of regex expressions.
 
     Returns:
-        [list(int)] -- list of pids
+        list(int): List of pids.
     &#34;&#34;&#34;
-    excludes = excludes or []
     res = []
-    for process in psutil.process_iter():
-        try:
-            cmdline = process.cmdline()
-        except psutil.NoSuchProcess:
-            cmdline = None
-        except psutil.AccessDenied:
-            cmdline = None
-        if cmdline:
-            name = &#34; &#34;.join(cmdline)
+    for process in psutil.process_iter(attrs=[&#34;cmdline&#34;]):
+        if process.info[&#34;cmdline&#34;]:
+            cmdline = &#34; &#34;.join(process.info[&#34;cmdline&#34;])
             for r in regex_list:
-                if name.strip() != &#34;&#34; and re.match(r, name):
+                if re.match(r, cmdline):
                     res.append(process.pid)
     return res</code></pre>
 </details>
@@ -1324,10 +1653,12 @@ excludes {list(str)} &ndash; list of excludes (default: {None})</p>
 </code></dt>
 <dd>
 <section class="desc"><p>Get pids of process by a filter string and optionally sort by sortkey</p>
-<h2 id="arguments">Arguments</h2>
-<p>filterstr {[str]} &ndash; filter string.
-Keyword Arguments:
-sortkey {[str]} &ndash; sort key for ps command (default: {None})
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>filterstr</code></strong> :&ensp;<code>str</code></dt>
+<dd>filter string.</dd>
+<dt><strong><code>sortkey</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>Defaults to None. (if no sortkey used it will sort by pid(s) ascending).
 sortkey can be one of the following:
 %cpu
 cpu utilization of the process in
@@ -1341,16 +1672,14 @@ egid
 effective group ID number of the process as a decimal integer.
 (alias gid).
 egroup
-effective group ID of the process.
-This will be the textual group ID, if it can be obtained and the field width permits, or a decimal representation otherwise.
+effective group ID of the process. This will be the textual group ID, if it can be obtained and the field width permits, or a decimal representation otherwise.
 (alias group).
 euid
 effective user ID (alias uid).
 euser
 effective user name.
 gid
-see egid.
-(alias egid).
+see egid. (alias egid).
 pid
 a number representing the process ID (alias tgid).
 ppid
@@ -1358,68 +1687,73 @@ parent process ID.
 psr
 processor that process is currently assigned to.
 start_time
-starting time or date of the process.</p>
+starting time or date of the process.</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[list(int)] &ndash; processes pids</p></section>
+<dl>
+<dt><code>list</code>(<code>int</code>): <code>processes</code> <code>pids</code></dt>
+<dd>&nbsp;</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_pids_filtered_sorted(filterstr, sortkey=None):
     &#34;&#34;&#34;Get pids of process by a filter string and optionally sort by sortkey
 
-    Arguments:
-        filterstr {[str]} -- filter string.
-
-    Keyword Arguments:
-        sortkey {[str]} -- sort key for ps command (default: {None})
-        sortkey can be one of the following:
-        %cpu           cpu utilization of the process in
-        %mem           ratio of the process&#39;s resident set size  to the physical memory on the machine, expressed as a percentage.
-        cputime        cumulative CPU time, &#34;[DD-]hh:mm:ss&#34; format.  (alias time).
-        egid           effective group ID number of the process as a decimal integer.  (alias gid).
-        egroup         effective group ID of the process.  This will be the textual group ID, if it can be obtained and the field width permits, or a decimal representation otherwise.  (alias group).
-        euid           effective user ID (alias uid).
-        euser          effective user name.
-        gid            see egid.  (alias egid).
-        pid            a number representing the process ID (alias tgid).
-        ppid           parent process ID.
-        psr            processor that process is currently assigned to.
-        start_time     starting time or date of the process.
-
+    Args:
+        filterstr (str): filter string.
+        sortkey (str, optional): Defaults to None. (if no sortkey used it will sort by pid(s) ascending).
+            sortkey can be one of the following:
+            %cpu           cpu utilization of the process in
+            %mem           ratio of the process&#39;s resident set size  to the physical memory on the machine, expressed as a percentage.
+            cputime        cumulative CPU time, &#34;[DD-]hh:mm:ss&#34; format.  (alias time).
+            egid           effective group ID number of the process as a decimal integer.  (alias gid).
+            egroup         effective group ID of the process. This will be the textual group ID, if it can be obtained and the field width permits, or a decimal representation otherwise.  (alias group).
+            euid           effective user ID (alias uid).
+            euser          effective user name.
+            gid            see egid. (alias egid).
+            pid            a number representing the process ID (alias tgid).
+            ppid           parent process ID.
+            psr            processor that process is currently assigned to.
+            start_time     starting time or date of the process.
 
     Returns:
-        [list(int)] -- processes pids
+        list(int): processes pids
     &#34;&#34;&#34;
-    if sortkey is not None:
-        cmd = &#34;ps aux --sort={sortkey} | grep &#39;{filterstr}&#39;&#34;.format(filterstr=filterstr, sortkey=sortkey)
+    ps_to_psutil_map = {
+        &#34;%cpu&#34;: &#34;cpu_percent&#34;,
+        &#34;%mem&#34;: &#34;memory_percent&#34;,
+        &#34;cputime&#34;: &#34;cpu_time&#34;,
+        &#34;psr&#34;: &#34;cpu_num&#34;,
+        &#34;start_time&#34;: &#34;create_time&#34;,
+        &#34;egid&#34;: &#34;egid&#34;,
+        &#34;gid&#34;: &#34;egid&#34;,
+        &#34;euid&#34;: &#34;euid&#34;,
+        &#34;uid&#34;: &#34;euid&#34;,
+        &#34;euser&#34;: &#34;username&#34;,
+        &#34;pid&#34;: &#34;pid&#34;,
+        &#34;ppid&#34;: &#34;ppid&#34;,
+    }
+    if sortkey is None:  # mimic default ps commnad sorting behavior
+        sortkey = &#34;pid&#34;
+        desc = False
     else:
-        cmd = &#34;ps ax | grep &#39;{filterstr}&#39;&#34;.format(filterstr=filterstr)
-    rc, out, err = execute(cmd)
-    # print out
-    found = []
-    for line in out.split(&#34;\n&#34;):
-        if line.find(&#34;grep&#34;) != -1 or line.strip() == &#34;&#34;:
-            continue
-        if line.strip() != &#34;&#34;:
-            if line.find(filterstr) != -1:
-                line = line.strip()
-                if sortkey is not None:
-                    found.append(int([x for x in line.split(&#34; &#34;) if x][1]))
-                else:
-                    found.append(int(line.split(&#34; &#34;)[0]))
-    return found</code></pre>
+        desc = True
+    # return pids from process objects
+    return [p[&#34;pid&#34;] for p in get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)]</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_ports_mapping"><code class="name flex">
 <span>def <span class="ident">get_ports_mapping</span></span>(<span>status=&#39;LISTEN&#39;)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>get a mapping for process to ports with a status filter</p>
-<p>it will skip any process in case of errors (e.g. permission error)</p>
-<p>example:</p>
-<pre><code class="python">j.sals.process.get_ports_mapping(psutil.CONN_ESTABLISHED)
-</code></pre>
-<p>or</p>
-<pre><code>j.sals.process.get_ports_mapping(&quot;ESTABLISHED&quot;)
+<section class="desc"><p>Get a mapping for process to ports with a status filter</p>
+<p>It will skip any process in case of errors (e.g. permission error)</p>
+<h2 id="example">Example</h2>
+<pre><code>&gt;&gt;&gt; from jumpscale.loader import j
+&gt;&gt;&gt; import psutil
+&gt;&gt;&gt; j.sals.process.get_ports_mapping(psutil.CONN_ESTABLISHED)
+&gt;&gt;&gt; # or
+&gt;&gt;&gt; j.sals.process.get_ports_mapping("ESTABLISHED")
 </code></pre>
 <h2 id="args">Args</h2>
 <dl>
@@ -1434,22 +1768,16 @@ starting time or date of the process.</p>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_ports_mapping(status=psutil.CONN_LISTEN):
-    &#34;&#34;&#34;
-    get a mapping for process to ports with a status filter
+    &#34;&#34;&#34;Get a mapping for process to ports with a status filter
 
-    it will skip any process in case of errors (e.g. permission error)
+    It will skip any process in case of errors (e.g. permission error)
 
-    example:
-
-    ```python
-    j.sals.process.get_ports_mapping(psutil.CONN_ESTABLISHED)
-    ```
-
-    or
-
-    ```
-    j.sals.process.get_ports_mapping(&#34;ESTABLISHED&#34;)
-    ```
+    Example:
+        &gt;&gt;&gt; from jumpscale.loader import j
+        &gt;&gt;&gt; import psutil
+        &gt;&gt;&gt; j.sals.process.get_ports_mapping(psutil.CONN_ESTABLISHED)
+        &gt;&gt;&gt; # or
+        &gt;&gt;&gt; j.sals.process.get_ports_mapping(&#34;ESTABLISHED&#34;)
 
     Args:
         status (psutil.CONN_CONSTANT): `psutil` CONN_* constant as a filter. Defaults to psutil.CONN_LISTEN.
@@ -1474,82 +1802,104 @@ starting time or date of the process.</p>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_process_by_port"><code class="name flex">
-<span>def <span class="ident">get_process_by_port</span></span>(<span>port)</span>
+<span>def <span class="ident">get_process_by_port</span></span>(<span>port, ipv6=False, udp=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns the full name of the process that is listening on the given port</p>
-<h2 id="arguments">Arguments</h2>
-<p>port (int) &ndash; the port for which to find the command</p>
+<section class="desc"><p>Returns the psutil.Process object that is listening on the given port.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>The port for which to find the process.</dd>
+<dt><strong><code>ipv6</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.</dd>
+<dt><strong><code>udp</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to search the connections for UDP port instead of TCP. Defaults to False.</dd>
+</dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><code>Runtime</code> <code>Error</code> <code>if</code> <code>the</code> <code>process</code> <code>is</code> <code>not</code> <code>accessible</code> <code>by</code> <code>the</code> <code>user</code></dt>
+<dt><code>j.exceptions.Runtime</code>: <code>if</code> <code>the</code> <code>process</code> <code>is</code> <code>not</code> <code>accessible</code> <code>by</code> <code>the</code> <code>user</code>, or <code>no</code> <code>longer</code> <code>exists</code></dt>
 <dd>&nbsp;</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt>[psutil.Process] &ndash; process object</dt>
-<dt><code>None</code> &ndash; <code>No</code> <code>process</code> <code>found</code></dt>
+<dt><code>psutil.Process</code>: <code>process</code> <code>object</code> <code>if</code> <code>found</code>, <code>otherwise</code> <code>None</code></dt>
 <dd>&nbsp;</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def get_process_by_port(port):
-    &#34;&#34;&#34;Returns the full name of the process that is listening on the given port
+<pre><code class="python">def get_process_by_port(port, ipv6=False, udp=False):
+    &#34;&#34;&#34;Returns the psutil.Process object that is listening on the given port.
 
-    Arguments:
-        port (int) -- the port for which to find the command
+    Args:
+        port (int): The port for which to find the process.
+        ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
+        udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
 
     Raises:
-        Runtime Error if the process is not accessible by the user
+        j.exceptions.Runtime: if the process is not accessible by the user, or no longer exists
 
     Returns:
-        [psutil.Process] -- process object
-        None -- No process found
+        psutil.Process: process object if found, otherwise None
     &#34;&#34;&#34;
-    pcons = [proc for proc in psutil.net_connections() if proc.laddr.port == port and proc.status == &#34;LISTEN&#34;]
-    if pcons:
-        pid = pcons[0].pid
-        if not pid:
-            raise j.exceptions.Runtime(&#34;No pid found maybe permission denied on the process&#34;)
-        return psutil.Process(pid)</code></pre>
+    for conn in psutil.net_connections():  # TODO use kind parameter
+        try:
+            # XXX should we check against ESTABLISHED status?
+            # connection.status For UDP and UNIX sockets this is always going to be psutil.CONN_NONE
+            if (
+                conn.laddr.port == port
+                and conn.status in [&#34;LISTEN&#34;, &#34;NONE&#34;, &#34;ESTABLISHED&#34;]
+                and (conn.family.name == &#34;AF_INET6&#34;) == ipv6
+                and (conn.type.name == &#34;SOCK_DGRAM&#34;) == udp
+            ):
+                if conn.pid:
+                    return psutil.Process(conn.pid)
+                else:
+                    raise j.exceptions.Runtime(&#34;pid is not retrievable, root is needed?&#34;)
+        except psutil.NoSuchProcess:
+            raise j.exceptions.Runtime(&#34;Process is no longer exists&#34;)
+        except psutil.AccessDenied:
+            raise j.exceptions.Runtime(&#34;Permission denied&#34;)</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_process_object"><code class="name flex">
 <span>def <span class="ident">get_process_object</span></span>(<span>pid, die=True)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get Process object of a process id</p>
-<h2 id="arguments">Arguments</h2>
-<p>pid (int) &ndash; pid of the process
-Keyword Arguments:
-die {bool} &ndash; die if process not found (default: {True})</p>
-<h2 id="raises">Raises</h2>
+<section class="desc"><p>Get psutil.Process object of a given process ID (PID).</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><code>psutil.NoSuchProcess</code>: <code>if</code> <code>process</code> <code>not</code> <code>found</code> <code>and</code> <code>die</code> = <code>True</code></dt>
-<dd>&nbsp;</dd>
+<dt><strong><code>pid</code></strong> :&ensp;<code>int</code></dt>
+<dd>Process ID (PID) to get</dd>
+<dt><strong><code>die</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to raise an exception if no process with the given PID is found in the
+current process list or not. Defaults to True.</dd>
 </dl>
+<h2 id="raises">Raises</h2>
+<p>psutil.NoSuchProcess: If process with the given PID is not found and die set to True.
+psutil.AccessDenied: If permission denied.</p>
 <h2 id="returns">Returns</h2>
-<p>[psutil.Process] &ndash; process object</p></section>
+<p>psutil.Process or None: psutil.Process object if he given PID is found, None otherwise.</p></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_process_object(pid, die=True):
-    &#34;&#34;&#34;Get Process object of a process id
+    &#34;&#34;&#34;Get psutil.Process object of a given process ID (PID).
 
-    Arguments:
-        pid (int) -- pid of the process
-
-    Keyword Arguments:
-        die {bool} -- die if process not found (default: {True})
+    Args:
+        pid (int): Process ID (PID) to get
+        die (bool, optional): Whether to raise an exception if no process with the given PID is found in the \
+            current process list or not. Defaults to True.
 
     Raises:
-        psutil.NoSuchProcess: if process not found and die = True
+        psutil.NoSuchProcess: If process with the given PID is not found and die set to True.
+        psutil.AccessDenied: If permission denied.
 
     Returns:
-        [psutil.Process] -- process object
+        psutil.Process or None: psutil.Process object if he given PID is found, None otherwise.
     &#34;&#34;&#34;
     try:
         return psutil.Process(pid)
-    except psutil.NoSuchProcess as e:
+    except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess) as e:
+        # when you query processess owned by another user, especially on macOS and Windows you may get AccessDenied exception
         if die:
             raise e
         else:
@@ -1560,156 +1910,304 @@ die {bool} &ndash; die if process not found (default: {True})</p>
 <span>def <span class="ident">get_processes</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>get an interator for all running processes</p>
+<section class="desc"><p>Get an interator for all running processes</p>
 <h2 id="yields">Yields</h2>
 <dl>
-<dt><strong><code>generator</code></strong></dt>
-<dd>for all processes</dd>
+<dt><code>psutil.Process</code>: <code>for</code> <code>all</code> <code>processes</code> <code>running</code></dt>
+<dd>&nbsp;</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_processes():
-    &#34;&#34;&#34;
-    get an interator for all running processes
+    &#34;&#34;&#34;Get an interator for all running processes
 
     Yields:
-        generator: for all processes
+        psutil.Process: for all processes running
     &#34;&#34;&#34;
     yield from psutil.process_iter()</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_processes_info"><code class="name flex">
-<span>def <span class="ident">get_processes_info</span></span>(<span>)</span>
+<span>def <span class="ident">get_processes_info</span></span>(<span>user=None, sort=&#39;mem&#39;, filterstr=None, limit=25, desc=True)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get information for top 25 running processes sorted by memory usage</p>
+<section class="desc"><p>Get information for top running processes sorted by memory usage or CPU usage.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>user</code></strong> :&ensp;[<code>type</code>], optional</dt>
+<dd>filter the processes by username. Defaults to None.</dd>
+<dt><strong><code>sort</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>sort processes by resource usage, Defaults to 'mem'.
+available option:
+'rss' and its alias 'mem': sort by processes which consumed the most memory (Resident Set Size).
+'cpu_times' and its alias 'cpu_time': sort by processes which consumed the most CPU time.
+'cpu_num': sort by the CPU number this process is currently running on.
+'cpu_percent': sort by a float representing the process CPU utilization as a percentage which can also
+be &gt; 100.0 in case of a process running multiple threads on different CPUs.
+'memory_percent': sort py the process memory utilization, the process memory to total physical system memory as a percentage
+'create_time': the process creation time as a floating point number expressed in seconds since the epoch.
+'gids' and its alias 'egid': the effective group id of this process
+'uids' and its alias 'euid': the effective user id of this process
+'pid': sort by the process PID.
+'ppid': sort by the process parent PID
+'name': sort by the processes name
+'username': sort by the name of the user that owns the process.
+'status': sort by the current process status, one of the psutil.STATUS_* constants</dd>
+<dt><strong><code>filterstr</code></strong> :&ensp;<code>str</code>, optional</dt>
+<dd>the string to match against process name or command used and filter the results based on.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>limit the results to specific number of processes, to disable set it to -1. Defaults to 25.</dd>
+<dt><strong><code>desc</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>whether to sort the data returned in descending order or not. Defaults to True.</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[list(dict)] &ndash; list of processes info</p></section>
+<dl>
+<dt><strong><code>dict</code></strong></dt>
+<dd>processes info as a dictionary
+available keys [
+"cpu_num",
+"cpu_percent",
+"cpu_times",
+"create_time",
+"gids",
+"memory_percent",
+"name",
+"pid",
+"ppid",
+"status",
+"uids",
+"username",
+"rss",
+"cpu_time",
+"ports"
+]</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def get_processes_info():
-    &#34;&#34;&#34;
-    Get information for top 25 running processes sorted by memory usage
+<pre><code class="python">def get_processes_info(user=None, sort=&#34;mem&#34;, filterstr=None, limit=25, desc=True):
+    &#34;&#34;&#34;Get information for top running processes sorted by memory usage or CPU usage.
+
+    Args:
+        user ([type], optional): filter the processes by username. Defaults to None.
+        sort (str, optional): sort processes by resource usage, Defaults to &#39;mem&#39;.
+            available option:
+                &#39;rss&#39; and its alias &#39;mem&#39;: sort by processes which consumed the most memory (Resident Set Size).
+                &#39;cpu_times&#39; and its alias &#39;cpu_time&#39;: sort by processes which consumed the most CPU time.
+                &#39;cpu_num&#39;: sort by the CPU number this process is currently running on.
+                &#39;cpu_percent&#39;: sort by a float representing the process CPU utilization as a percentage which can also\
+                    be &gt; 100.0 in case of a process running multiple threads on different CPUs.
+                &#39;memory_percent&#39;: sort py the process memory utilization, the process memory to total physical system memory as a percentage
+                &#39;create_time&#39;: the process creation time as a floating point number expressed in seconds since the epoch.
+                &#39;gids&#39; and its alias &#39;egid&#39;: the effective group id of this process
+                &#39;uids&#39; and its alias &#39;euid&#39;: the effective user id of this process
+                &#39;pid&#39;: sort by the process PID.
+                &#39;ppid&#39;: sort by the process parent PID
+                &#39;name&#39;: sort by the processes name
+                &#39;username&#39;: sort by the name of the user that owns the process.
+                &#39;status&#39;: sort by the current process status, one of the psutil.STATUS_* constants
+        filterstr (str, optional): the string to match against process name or command used and filter the results based on.
+        limit (int, optional): limit the results to specific number of processes, to disable set it to -1. Defaults to 25.
+        desc (bool, optional): whether to sort the data returned in descending order or not. Defaults to True.
 
     Returns:
-        [list(dict)] -- list of processes info
+        dict: processes info as a dictionary
+            available keys [
+                    &#34;cpu_num&#34;,
+                    &#34;cpu_percent&#34;,
+                    &#34;cpu_times&#34;,
+                    &#34;create_time&#34;,
+                    &#34;gids&#34;,
+                    &#34;memory_percent&#34;,
+                    &#34;name&#34;,
+                    &#34;pid&#34;,
+                    &#34;ppid&#34;,
+                    &#34;status&#34;,
+                    &#34;uids&#34;,
+                    &#34;username&#34;,
+                    &#34;rss&#34;,
+                    &#34;cpu_time&#34;,
+                    &#34;ports&#34;
+                ]
     &#34;&#34;&#34;
+
+    def _get_sort_key(procObj):
+        if sort == &#34;mem&#34;:
+            return procObj[&#34;rss&#34;]
+        if sort == &#34;cpu_times&#34;:
+            return procObj[&#34;cpu_time&#34;]
+        elif sort in [&#34;gids&#34;, &#34;egid&#34;]:
+            return procObj[&#34;gids&#34;].effective
+        elif sort in [&#34;uids&#34;, &#34;euid&#34;]:
+            return procObj[&#34;uids&#34;].effective
+        else:
+            try:
+                return procObj[sort]
+            except KeyError as e:
+                j.logger.error(f&#34;bad field name for sorting: {sort}&#34;)
+                raise j.exceptions.Value(f&#34;bad field name for sorting: {sort}&#34;)
+
     processes_list = []
-    for proc in get_processes():
+    j.logger.debug(f&#34;Args used: user={user}, sort={sort}, filterstr={filterstr}, limit={limit}, desc={desc}&#34;)
+    if not filterstr:
+        p_source = get_processes() if not user else get_user_processes(user=user)
+    else:
+        # XXX it makes sense that get_pids func should returns list of psutil.Process objects instead of list of pids
+        p_source = (
+            map(get_process_object, get_pids(process_name=filterstr))
+            if not user
+            else map(get_process_object, get_pids(process_name=filterstr, _alt_source=get_user_processes(user)))
+        )
+    for proc in p_source:
         try:
             # Fetch process details as dict
-            pinfo = proc.as_dict(attrs=[&#34;pid&#34;, &#34;name&#34;, &#34;username&#34;])
-            pinfo[&#34;rss&#34;] = proc.memory_info().rss / (1024 * 1024)
+            pinfo = proc.as_dict(
+                attrs=[
+                    &#34;cpu_num&#34;,
+                    &#34;cpu_percent&#34;,
+                    &#34;cpu_times&#34;,
+                    &#34;create_time&#34;,
+                    &#34;gids&#34;,
+                    &#34;memory_percent&#34;,
+                    &#34;name&#34;,
+                    &#34;pid&#34;,
+                    &#34;ppid&#34;,
+                    &#34;status&#34;,
+                    &#34;uids&#34;,
+                    &#34;username&#34;,
+                ]
+            )
+            pinfo[&#34;rss&#34;] = proc.memory_info().rss / (
+                1024 * 1024
+            )  # the non-swapped physical memory a process has used in Mb
+            pinfo[&#34;cpu_time&#34;] = sum(pinfo[&#34;cpu_times&#34;][:2])  # cumulative, excluding children and iowait
             pinfo[&#34;ports&#34;] = []
-            try:
-                connections = proc.connections()
-            except psutil.Error:
-                continue
+            connections = proc.connections()  # need root
             if connections:
                 for conn in connections:
                     pinfo[&#34;ports&#34;].append({&#34;port&#34;: conn.laddr.port, &#34;status&#34;: conn.status})
             # Append dict to list
             processes_list.append(pinfo)
-        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as e:
+            j.logger.debug(
+                &#34;ignoring and logging an exception that occurred while iterating over system processes, not root?&#34;
+            )
+            # j.logger.exception(&#39;an exception occurred while iterating over system processes&#39;, exception=e)
             pass
-    processes_list = sorted(processes_list, key=lambda procObj: procObj[&#34;rss&#34;], reverse=True)
-    return processes_list[:25]</code></pre>
+    j.logger.debug(f&#34;Processes found: {len(processes_list)}&#34;)
+    # sort the processes list by sort_key
+    sorted_processes = sorted(processes_list, key=_get_sort_key, reverse=desc)[:limit]
+    return sorted_processes</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_similar_processes"><code class="name flex">
-<span>def <span class="ident">get_similar_processes</span></span>(<span>)</span>
+<span>def <span class="ident">get_similar_processes</span></span>(<span>target_proc=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets similar processes to current process</p>
+<section class="desc"><p>Gets similar processes to current process, started with same command line and same options.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>target_proc</code></strong> :&ensp;<code>int</code> or <code>psutil.Process</code>, optional</dt>
+<dd>pid, or psutil.Process object,
+if None then pid for current process will be used. Defaults to None.</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[list(psutil.Process)] &ndash; list of similar process</p></section>
+<dl>
+<dt><code>list</code>[<code>psutil.Process</code>] &ndash; <code>list</code> of <code>similar</code> <code>process</code></dt>
+<dd>&nbsp;</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def get_similar_processes():
-    &#34;&#34;&#34;Gets similar processes to current process
+<pre><code class="python">def get_similar_processes(target_proc=None):
+    &#34;&#34;&#34;Gets similar processes to current process, started with same command line and same options.
 
+    Args:
+        target_proc (int or psutil.Process, optional): pid, or psutil.Process object,\
+             if None then pid for current process will be used. Defaults to None.
     Returns:
-        [list(psutil.Process)] -- list of similar process
+        list[psutil.Process] -- list of similar process
     &#34;&#34;&#34;
-    myprocess = get_my_process()
-    result = []
-    for item in psutil.process_iter():
-        try:
-            if item.cmdline() == myprocess.cmdline():
-                result.append(item)
-        except psutil.NoSuchProcess:
-            pass
-    return result</code></pre>
+    try:
+        if target_proc is None:
+            target_proc = get_my_process()
+        elif isinstance(target_proc, int):
+            target_proc = get_process_object(target_proc)
+        for proc in psutil.process_iter([&#34;name&#34;, &#34;cmdline&#34;]):
+            if proc.info[&#34;cmdline&#34;] and target_proc.cmdline() and proc.info[&#34;cmdline&#34;] == target_proc.cmdline():
+                yield proc
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        pass</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.get_user_processes"><code class="name flex">
 <span>def <span class="ident">get_user_processes</span></span>(<span>user)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get all process for a specific user</p>
-<h2 id="arguments">Arguments</h2>
-<p>user {str} &ndash; username</p>
-<h2 id="returns">Returns</h2>
-<p>[list(int)] &ndash; list of process pids for that user</p></section>
+<section class="desc"><p>Get all process for a specific user.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>user</code></strong> :&ensp;<code>str</code></dt>
+<dd>Te user name to match against.</dd>
+</dl>
+<h2 id="yields">Yields</h2>
+<p>psutil.Process: psutil.Process object for all processes owned by <code>user</code>.</p></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def get_user_processes(user):
-    &#34;&#34;&#34;Get all process for a specific user
+    &#34;&#34;&#34;Get all process for a specific user.
 
-    Arguments:
-        user {str} -- username
+    Args:
+        user (str): Te user name to match against.
 
-    Returns:
-        [list(int)] -- list of process pids for that user
+    Yields:
+        psutil.Process: psutil.Process object for all processes owned by `user`.
     &#34;&#34;&#34;
-    result = []
-    for process in psutil.process_iter():
-        if process.username() == user:
-            result.append(process.pid)
-    return result</code></pre>
+    try:
+        for process in psutil.process_iter():
+            if process.username() == user:
+                yield process
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        pass</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.in_docker"><code class="name flex">
 <span>def <span class="ident">in_docker</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>will check if we are in a docker</p>
+<section class="desc"><p>will check if we are in a docker.</p>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt><strong><code>Bool</code></strong></dt>
-<dd>True if in docker - False if not</dd>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if in docker. False otherwise.</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def in_docker():
-    &#34;&#34;&#34;will check if we are in a docker
+    &#34;&#34;&#34;will check if we are in a docker.
 
     Returns:
-        Bool: True if in docker - False if not
+        bool: True if in docker. False otherwise.
     &#34;&#34;&#34;
     rc, out, _ = j.sals.process.execute(&#34;cat /proc/1/cgroup&#34;, die=False, showout=False)
-    if rc == 0 and &#34;/docker/&#34; in out:
-        return True
-    return False</code></pre>
+    return rc == 0 and &#34;/docker/&#34; in out</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.in_host"><code class="name flex">
 <span>def <span class="ident">in_host</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>will check if we are in a host</p>
+<section class="desc"><p>Will check if we are in a host.</p>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt><strong><code>Bool</code></strong></dt>
-<dd>True if in host - False if not</dd>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if in host. False otherwise.</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def in_host():
-    &#34;&#34;&#34;will check if we are in a host
+    &#34;&#34;&#34;Will check if we are in a host.
 
     Returns:
-        Bool: True if in host - False if not
+        bool: True if in host. False otherwise.
     &#34;&#34;&#34;
     return not in_docker()</code></pre>
 </details>
@@ -1718,23 +2216,28 @@ die {bool} &ndash; die if process not found (default: {True})</p>
 <span>def <span class="ident">is_alive</span></span>(<span>pid)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Checks if pid is Running</p>
-<h2 id="arguments">Arguments</h2>
-<p>pid (int) &ndash; pid of the process to be checked</p>
+<section class="desc"><p>Check whether the given PID exists in the current process list.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>pid</code></strong> :&ensp;<code>int</code></dt>
+<dd>Process ID (PID) to be checked.</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[bool] &ndash; True if process is running</p></section>
+<dl>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if the given PID exists in the current process list, False otherwise.</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def is_alive(pid):
-    &#34;&#34;&#34;Checks if pid is Running
+    &#34;&#34;&#34;Check whether the given PID exists in the current process list.
 
-    Arguments:
-        pid (int) -- pid of the process to be checked
+    Args:
+        pid (int): Process ID (PID) to be checked.
 
     Returns:
-        [bool] -- True if process is running
+        bool: True if the given PID exists in the current process list, False otherwise.
     &#34;&#34;&#34;
-    pid = int(pid)
     return psutil.pid_exists(pid)</code></pre>
 </details>
 </dd>
@@ -1742,250 +2245,448 @@ die {bool} &ndash; die if process not found (default: {True})</p>
 <span>def <span class="ident">is_installed</span></span>(<span>cmd)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>[summary]
-Checks if a specific command is available on system e.g. curl</p>
-<h2 id="arguments">Arguments</h2>
-<p>cmd {str} &ndash; command to be checked</p>
-<h2 id="returns">Returns</h2>
-<p>[bool] &ndash; True if command is installed</p></section>
-<details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def is_installed(cmd):
-    &#34;&#34;&#34;[summary]
-    Checks if a specific command is available on system e.g. curl
-    Arguments:
-        cmd {str} -- command to be checked
-
-    Returns:
-        [bool] -- True if command is installed
-    &#34;&#34;&#34;
-    rc, _, _ = execute(&#34;which %s&#34; % cmd, die=False)
-    if rc:
-        return False
-    else:
-        return True</code></pre>
-</details>
-</dd>
-<dt id="jumpscale.sals.process.is_port_listening"><code class="name flex">
-<span>def <span class="ident">is_port_listening</span></span>(<span>port)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>check if the port is being used by any process</p>
+<section class="desc"><p>Checks if a specific command is available on system e.g. curl.</p>
 <h2 id="args">Args</h2>
 <dl>
-<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
-<dd>port number</dd>
+<dt><strong><code>cmd</code></strong> :&ensp;<code>str</code></dt>
+<dd>Command to be checked.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <dl>
-<dt><strong><code>Bool</code></strong></dt>
-<dd>True if port is used else False</dd>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if command is available, False otherwise.</dd>
 </dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def is_port_listening(port):
-    &#34;&#34;&#34;check if the port is being used by any process
+<pre><code class="python">def is_installed(cmd):
+    &#34;&#34;&#34;Checks if a specific command is available on system e.g. curl.
 
     Args:
-        port (int): port number
+        cmd (str): Command to be checked.
 
     Returns:
-        Bool: True if port is used else False
+        bool: True if command is available, False otherwise.
     &#34;&#34;&#34;
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        result = s.connect_ex((&#34;127.0.0.1&#34;, port))
-    return result == 0</code></pre>
+    rc, _, _ = execute(f&#34;which {cmd}&#34;, die=False)
+    return rc == 0</code></pre>
+</details>
+</dd>
+<dt id="jumpscale.sals.process.is_port_listening"><code class="name flex">
+<span>def <span class="ident">is_port_listening</span></span>(<span>port, ipv6=False)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Check if the TCP port is being used by any process</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>Port number</dd>
+<dt><strong><code>ipv6</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to ipv6 localhost address instead of ipv4 localhost address. Defaults to False.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if port is used, False otherwise.</dd>
+</dl></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def is_port_listening(port, ipv6=False):
+    &#34;&#34;&#34;Check if the TCP port is being used by any process
+
+    Args:
+        port (int): Port number
+        ipv6 (bool, optional): Whether to ipv6 localhost address instead of ipv4 localhost address. Defaults to False.
+
+    Returns:
+        bool: True if port is used, False otherwise.
+    &#34;&#34;&#34;
+    # XXX only support ipv4, also it apparently used to pick a free port, any way using nettools is preferred
+    from jumpscale.sals import nettools
+
+    ip6 = &#34;::&#34;
+    ip4 = &#34;0.0.0.0&#34;
+    return nettools.tcp_connection_test(ip6 if ipv6 else ip4, port, timeout=5)</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.kill"><code class="name flex">
-<span>def <span class="ident">kill</span></span>(<span>pid, sig=15)</span>
+<span>def <span class="ident">kill</span></span>(<span>proc, sig=&lt;Signals.SIGTERM: 15&gt;, timeout=5, sure_kill=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Kill a process with a signal</p>
-<h2 id="arguments">Arguments</h2>
-<p>pid (int) &ndash; pid of the process to be killed
-Keyword Arguments:
-sig {int]} &ndash; which signal you want to kill the process with (default: {signal.SIGTERM.value})</p>
-<h2 id="raises">Raises</h2>
+<section class="desc"><p>Kill a process with a specified signal.</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><code>j.exceptions.RuntimeError</code>: <code>in</code> <code>case</code> <code>killing</code> <code>process</code> <code>failed</code></dt>
-<dd>&nbsp;</dd>
+<dt>proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.</dt>
+<dt><strong><code>sig</code></strong> :&ensp;<code>signal</code>, optional</dt>
+<dd>See signal module constants. Defaults to signal.SIGTERM.</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>How long to wait for a process to terminate (seconds) before raise exception
+or, if sure_kill=True, send a SIGKILL. Defaults to 5.</dd>
+<dt><strong><code>sure_kill</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.</dd>
 </dl>
+<h2 id="raises">Raises</h2>
+<p>j.exceptions.Runtime: In case killing the process failed.
+j.exceptions.Permission: In case the permission to perform this action is denied.</p>
 <h2 id="returns">Returns</h2>
-<p>[type] &ndash; [description]</p></section>
+<dl>
+<dt><code>None</code></dt>
+<dd>&nbsp;</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def kill(pid, sig=signal.SIGTERM.value):
-    &#34;&#34;&#34;Kill a process with a signal
+<pre><code class="python">def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
+    &#34;&#34;&#34;Kill a process with a specified signal.
 
-    Arguments:
-        pid (int) -- pid of the process to be killed
-
-    Keyword Arguments:
-        sig {int]} -- which signal you want to kill the process with (default: {signal.SIGTERM.value})
+    Args:
+        proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Raises:
-        j.exceptions.RuntimeError: in case killing process failed
+        j.exceptions.Runtime: In case killing the process failed.
+        j.exceptions.Permission: In case the permission to perform this action is denied.
 
     Returns:
-        [type] -- [description]
+        None
     &#34;&#34;&#34;
-    pid = int(pid)
-    sig = int(sig)
-    proc = psutil.Process(pid)
     try:
+        if isinstance(proc, int):
+            proc = get_process_object(proc)
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            return True
         proc.send_signal(sig)
-        return True
-    except Exception as e:
-        raise j.exceptions.RuntimeError(&#34;Could not kill process with id %s.\n%s&#34; % (pid, e))</code></pre>
+        # Wait for a process to terminate
+        # If PID no longer exists return None immediately
+        # If timeout exceeded and the process is still alive raise TimeoutExpired exception
+        proc.wait(timeout=timeout)
+        j.logger.debug(f&#34;the process with PID: {proc.pid} was terminated with sig: {sig}.&#34;)
+        return True  # XXX only to pass current tests
+    except psutil.TimeoutExpired as e:
+        # timeout expires and process is still alive.
+        if sure_kill and sig != signal.SIGKILL and os.name != &#34;nt&#34;:
+            # SIGKILL not supported in windows
+            # If a process gets this signal it must quit immediately and will not perform any clean-up operations
+            proc.kill()
+            j.logger.debug(&#34;SIGKILL signal sent.&#34;)
+            try:
+                proc.wait(1)
+                j.logger.debug(f&#34;the process with PID: {proc.pid} was terminated with sig: {signal.SIGKILL}.&#34;)
+            except psutil.TimeoutExpired as e:
+                if proc.status() == psutil.STATUS_ZOMBIE:
+                    j.logger.debug(
+                        f&#34;the process with PID: {proc.pid} becomes a zombie and should be considered a dead.&#34;
+                    )
+                    return True
+                # the process may be in an uninterruptible sleep
+                j.logger.debug(&#34;the process may be in an uninterruptible sleep.&#34;)
+                j.logger.warning(f&#34;Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}&#34;)
+                raise j.exceptions.Runtime(f&#34;Could not kill process with pid {proc.pid}, {proc.status()}&#34;) from e
+            return True  # XXX only to pass current tests
+        else:
+            j.logger.warning(f&#34;Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}&#34;)
+            raise j.exceptions.Runtime(f&#34;Could not kill process with pid {proc.pid}&#34;) from e
+    except psutil.AccessDenied as e:
+        # permission to perform an action is denied
+        j.logger.warning(&#34;the permission is denied&#34;)
+        raise j.exceptions.Permission(&#34;Permission to perform this action is denied!&#34;) from e
+    except (psutil.ZombieProcess, psutil.NoSuchProcess):
+        # Process no longer exists or Zombie (already dead)
+        j.logger.debug(&#34;Process is no longer exists or a Zombie (already dead)&#34;)
+        return True</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.kill_all"><code class="name flex">
-<span>def <span class="ident">kill_all</span></span>(<span>name, sig=&lt;Signals.SIGKILL: 9&gt;)</span>
+<span>def <span class="ident">kill_all</span></span>(<span>process_name, sig=&lt;Signals.SIGKILL: 9&gt;)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Kill all processes with a given name</p>
-<h2 id="arguments">Arguments</h2>
-<p>name {str} &ndash; process name
-Keyword Arguments:
-sig (int) &ndash; signal number (default: {signal.SIGKILL})</p></section>
+<section class="desc"><p>Kill all processes that match 'process_name'.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>process_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The target process name</dd>
+<dt><strong><code>sig</code></strong> :&ensp;<code>signal</code>, optional</dt>
+<dd>See signal module constants. Defaults to signal.SIGKILL</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None or list[int] represents the IDs of the processes remaning alive.</p></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def kill_all(name, sig=signal.SIGKILL):
-    &#34;&#34;&#34;Kill all processes with a given name
+<pre><code class="python">def kill_all(process_name, sig=signal.SIGKILL):
+    &#34;&#34;&#34;Kill all processes that match &#39;process_name&#39;.
 
-    Arguments:
-        name {str} -- process name
+    Args:
+        process_name (str): The target process name
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL
 
-    Keyword Arguments:
-        sig (int) -- signal number (default: {signal.SIGKILL})
+    Returns:
+        None or list[int] represents the IDs of the processes remaning alive.
     &#34;&#34;&#34;
-    sig = int(sig)
-    for proc in psutil.process_iter():
-        if proc.name() == name:
-            kill(proc.pid, sig)</code></pre>
+    # XXX kill default to SIGTERM while kill_all default to SIGKILL (inconsistency)?
+    # XXX almost like kill_process_by_name
+    failed_processes = kill_process_by_name(process_name, sig)
+    return failed_processes</code></pre>
+</details>
+</dd>
+<dt id="jumpscale.sals.process.kill_proc_tree"><code class="name flex">
+<span>def <span class="ident">kill_proc_tree</span></span>(<span>parent, sig=&lt;Signals.SIGTERM: 15&gt;, include_parent=True, include_grand_children=True, timeout=5, sure_kill=False)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Kill a process and its children (including grandchildren) with signal <code>sig</code></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt>proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.</dt>
+<dt><strong><code>sig</code></strong> :&ensp;<code>signal</code>, optional</dt>
+<dd>See signal module constants. Defaults to signal.SIGTERM.</dd>
+<dt>include_parent (): Whether to kill the process itself. Defaults to True.</dt>
+<dt>include_grand_children (): whether to kill recursively all grandchildren. Defaults to True.</dt>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>How long to wait for a process to terminate (seconds) before raise exception
+or, if sure_kill=True, send a SIGKILL. Defaults to 5.</dd>
+<dt><strong><code>sure_kill</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>(list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.</p></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def kill_proc_tree(
+    parent, sig=signal.SIGTERM, include_parent=True, include_grand_children=True, timeout=5, sure_kill=False
+):
+    &#34;&#34;&#34;Kill a process and its children (including grandchildren) with signal `sig`
+
+    Args:
+        proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        include_parent (): Whether to kill the process itself. Defaults to True.
+        include_grand_children (): whether to kill recursively all grandchildren. Defaults to True.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
+
+    Returns:
+        (list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.
+    &#34;&#34;&#34;
+    if isinstance(parent, int):
+        try:
+            parent = get_process_object(parent)
+        except (psutil.AccessDenied, psutil.NoSuchProcess):
+            return
+
+    assert parent.pid != os.getpid(), &#34;won&#39;t kill myself&#34;
+
+    processes = parent.children(recursive=include_grand_children)[::-1]
+    failed = []
+    if include_parent:
+        processes.append(parent)
+
+    for p in processes:
+        try:
+            kill(p, sig=sig, timeout=timeout, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission):
+            failed.append(p)
+
+    # making sure
+    if failed:
+        gone, failed = psutil.wait_procs(failed, timeout=0)
+    return failed or None</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.kill_process_by_name"><code class="name flex">
-<span>def <span class="ident">kill_process_by_name</span></span>(<span>name, sig=15, match_predicate=None)</span>
+<span>def <span class="ident">kill_process_by_name</span></span>(<span>process_name, sig=&lt;Signals.SIGTERM: 15&gt;, match_predicate=None, timeout=5, sure_kill=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Kill all processes for a given command</p>
-<h2 id="arguments">Arguments</h2>
-<p>name {str} &ndash; Name of the command that started the process(s)
-Keyword Arguments:
-sig {bool} &ndash; os signal to send to the process(s) (default: {signal.SIGTERM.value})
-match_predicate {callable} &ndash; function that does matching between
-found processes and the targested process, the function should accept
-two arguments and return a boolean (default: {None})</p></section>
+<section class="desc"><p>Kill all processes that match 'process_name'.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>process_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The target process name.</dd>
+<dt><strong><code>sig</code></strong> :&ensp;<code>signal</code>, optional</dt>
+<dd>See signal module constants. Defaults to signal.SIGKILL</dd>
+<dt><strong><code>match_predicate</code></strong> :&ensp;<code>callable</code>, optional</dt>
+<dd>Function that does matching between
+found processes and the targeted process, the function should accept
+two arguments and return a boolean. Defaults to None.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None or list[int] represents the IDs of the processes remaning alive.</p></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def kill_process_by_name(name, sig=signal.SIGTERM.value, match_predicate=None):
-    &#34;&#34;&#34;Kill all processes for a given command
+<pre><code class="python">def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None, timeout=5, sure_kill=False):
+    &#34;&#34;&#34;Kill all processes that match &#39;process_name&#39;.
 
-    Arguments:
-        name {str} -- Name of the command that started the process(s)
+    Args:
+        process_name (str): The target process name.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL
+        match_predicate (callable, optional): Function that does matching between\
+            found processes and the targeted process, the function should accept\
+            two arguments and return a boolean. Defaults to None.
 
-    Keyword Arguments:
-        sig {bool} -- os signal to send to the process(s) (default: {signal.SIGTERM.value})
-        match_predicate {callable} -- function that does matching between
-            found processes and the targested process, the function should accept
-            two arguments and return a boolean (default: {None})
+    Returns:
+        None or list[int] represents the IDs of the processes remaning alive.
     &#34;&#34;&#34;
-
-    pids = get_pids(name, match_predicate=match_predicate)
+    pids = get_pids(process_name, match_predicate=match_predicate)
+    failed_processes = []
     for pid in pids:
-        kill(pid, sig)</code></pre>
+        try:
+            kill(pid, sig, timeout=timeout, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission) as e:
+            failed_processes.append(pid)
+    return failed_processes or None  # return None if the failed list is empty</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.kill_process_by_port"><code class="name flex">
-<span>def <span class="ident">kill_process_by_port</span></span>(<span>port)</span>
+<span>def <span class="ident">kill_process_by_port</span></span>(<span>port, ipv6=False, udp=False, sig=&lt;Signals.SIGTERM: 15&gt;, timeout=5, sure_kill=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Kill process by port</p>
-<h2 id="arguments">Arguments</h2>
-<p>port (int) &ndash; port number</p></section>
+<section class="desc"><p>Kill process by port.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>The port number.</dd>
+<dt><strong><code>ipv6</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.</dd>
+<dt><strong><code>udp</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to search the connections for UDP port instead of TCP. Defaults to False.</dd>
+<dt><strong><code>sig</code></strong> :&ensp;<code>signal</code>, optional</dt>
+<dd>See signal module constants. Defaults to signal.SIGTERM.</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>How long to wait for a process to terminate (seconds) before raise exception
+or, if sure_kill=True, send a SIGKILL. Defaults to 5.</dd>
+<dt><strong><code>sure_kill</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>None</code></dt>
+<dd>&nbsp;</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def kill_process_by_port(port):
-    &#34;&#34;&#34;Kill process by port
+<pre><code class="python">def kill_process_by_port(port, ipv6=False, udp=False, sig=signal.SIGTERM, timeout=5, sure_kill=False):
+    &#34;&#34;&#34;Kill process by port.
 
-    Arguments:
-        port (int) -- port number
+    Args:
+        port (int): The port number.
+        ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
+        udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
+
+    Returns:
+        None
     &#34;&#34;&#34;
-    port = int(port)
-    pid = get_pid_by_port(port)
-    if pid:
-        return kill(pid)</code></pre>
+    proc = get_process_by_port(port, ipv6=ipv6, udp=udp)
+    return kill(proc, sig=sig, timeout=timeout, sure_kill=sure_kill)</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.kill_user_processes"><code class="name flex">
-<span>def <span class="ident">kill_user_processes</span></span>(<span>user)</span>
+<span>def <span class="ident">kill_user_processes</span></span>(<span>user, sure_kill=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Kill all processes for a specific user</p>
-<h2 id="arguments">Arguments</h2>
-<p>user {str} &ndash; username</p></section>
+<section class="desc"><p>Kill all processes for a specific user.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>user</code></strong> :&ensp;<code>str</code></dt>
+<dd>The user name to match against.</dd>
+<dt><strong><code>sure_kill</code></strong> :&ensp;<code>bool</code>, optional</dt>
+<dd>Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>(list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.</p></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def kill_user_processes(user):
-    &#34;&#34;&#34;Kill all processes for a specific user
+<pre><code class="python">def kill_user_processes(user, sure_kill=False):
+    &#34;&#34;&#34;Kill all processes for a specific user.
 
-    Arguments:
-        user {str} -- username
+    Args:
+        user (str): The user name to match against.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
+
+    Returns:
+        (list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.
     &#34;&#34;&#34;
-    for pid in get_user_processes(user):
-        kill(pid)</code></pre>
+    failed_processes = []
+    for proc in get_user_processes(user):
+        try:
+            kill(proc, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission) as e:
+            j.logger.exception(&#34;exception occurred while iterating over user processes&#34;, exception=e)
+            j.logger.debug(&#34;ignoring the exception..&#34;)
+            failed_processes.append(proc)
+    j.logger.debug(
+        &#34;killing all user processes succeeded&#34; if not failed_processes else &#34;couldn&#39;t kill all user processes!&#34;
+    )
+
+    # making sure
+    if failed_processes:
+        gone, failed_processes = psutil.wait_procs(failed_processes, timeout=0)
+
+    j.logger.debug(f&#34;stay alive: {len(failed_processes)}, pids -&gt; {[p.pid for p in failed_processes]}&#34;)
+    return failed_processes or None  # return None if the failed list is empty</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.ps_find"><code class="name flex">
-<span>def <span class="ident">ps_find</span></span>(<span>name)</span>
+<span>def <span class="ident">ps_find</span></span>(<span>process_name)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>find process by name</p>
-<h2 id="arguments">Arguments</h2>
-<p>name {str} &ndash; process name</p>
+<section class="desc"><p>Check if there is any running process that match the given name.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>process_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The target process name. will match against against Process.name(),
+Process.exe() and Process.cmdline()</dd>
+</dl>
 <h2 id="returns">Returns</h2>
-<p>[bool] &ndash; True if process is found</p></section>
+<dl>
+<dt><strong><code>bool</code></strong></dt>
+<dd>True if process is found, False otherwise.</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def ps_find(name):
-    &#34;&#34;&#34;find process by name
+<pre><code class="python">def ps_find(process_name):
+    &#34;&#34;&#34;Check if there is any running process that match the given name.
 
-    Arguments:
-        name {str} -- process name
+    Args:
+        process_name (str): The target process name. will match against against Process.name(),\
+            Process.exe() and Process.cmdline()
 
     Returns:
-        [bool] -- True if process is found
+        bool: True if process is found, False otherwise.
     &#34;&#34;&#34;
-    for proc in psutil.process_iter():
-        if proc.name() == name:
-            return True
-    return False</code></pre>
+    return len(get_pids(process_name, limit=1)) == 1</code></pre>
 </details>
 </dd>
 <dt id="jumpscale.sals.process.set_env_var"><code class="name flex">
-<span>def <span class="ident">set_env_var</span></span>(<span>varnames, varvalues)</span>
+<span>def <span class="ident">set_env_var</span></span>(<span>var_names, var_values)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set the value of the environment variables C{varnames}. Existing variable are overwritten</p>
-<h2 id="arguments">Arguments</h2>
-<p>varnames {list(str)} &ndash;
-A list of the names of all the environment variables to set
-varvalues {list(str)} &ndash; A list of all values for the environment variables</p></section>
+<section class="desc"><p>Set the value of the environment variables {varnames}. Existing variable are overwritten</p>
+<h2 id="args">Args</h2>
+<p>var_names list[str]: A list of the names of all the environment variables to set
+varvalues list[str]: A list of all values for the environment variables</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>j.exceptions.RuntimeError</code>: <code>if</code> <code>error</code> <code>happened</code> <code>during</code> <code>setting</code> <code>the</code> <code>environment</code> <code>variables</code></dt>
+<dd>&nbsp;</dd>
+</dl></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def set_env_var(varnames, varvalues):
-    &#34;&#34;&#34;Set the value of the environment variables C{varnames}. Existing variable are overwritten
+<pre><code class="python">def set_env_var(var_names, var_values):
+    &#34;&#34;&#34;Set the value of the environment variables {varnames}. Existing variable are overwritten
 
-    Arguments:
-        varnames {list(str)} --  A list of the names of all the environment variables to set
-        varvalues {list(str)} -- A list of all values for the environment variables
-
+    Args:
+        var_names list[str]: A list of the names of all the environment variables to set
+        varvalues list[str]: A list of all values for the environment variables
+    Raises:
+        j.exceptions.RuntimeError: if error happened during setting the environment variables
     &#34;&#34;&#34;
     try:
-        for i in range(len(varnames)):
-            os.environ[varnames[i]] = str(varvalues[i]).strip()
+        for i in range(len(var_names)):
+            os.environ[var_names[i]] = str(var_values[i]).strip()
     except Exception as e:
         raise j.exceptions.RuntimeError(e)</code></pre>
 </details>
@@ -2036,6 +2737,7 @@ varvalues {list(str)} &ndash; A list of all values for the environment variables
 <li><code><a title="jumpscale.sals.process.is_port_listening" href="#jumpscale.sals.process.is_port_listening">is_port_listening</a></code></li>
 <li><code><a title="jumpscale.sals.process.kill" href="#jumpscale.sals.process.kill">kill</a></code></li>
 <li><code><a title="jumpscale.sals.process.kill_all" href="#jumpscale.sals.process.kill_all">kill_all</a></code></li>
+<li><code><a title="jumpscale.sals.process.kill_proc_tree" href="#jumpscale.sals.process.kill_proc_tree">kill_proc_tree</a></code></li>
 <li><code><a title="jumpscale.sals.process.kill_process_by_name" href="#jumpscale.sals.process.kill_process_by_name">kill_process_by_name</a></code></li>
 <li><code><a title="jumpscale.sals.process.kill_process_by_port" href="#jumpscale.sals.process.kill_process_by_port">kill_process_by_port</a></code></li>
 <li><code><a title="jumpscale.sals.process.kill_user_processes" href="#jumpscale.sals.process.kill_user_processes">kill_user_processes</a></code></li>

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -416,7 +416,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None, incl
     # default match predicate
     def default_predicate(target, given):
         if isinstance(given, list):
-            return target in " ".join(given)
+            return target in given
         else:
             return target.strip().lower() == given.lower()
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -24,6 +24,7 @@ Example:
 
 import math
 import os
+import time
 import subprocess
 import shlex
 import re
@@ -295,7 +296,7 @@ def get_pids_filtered_by_regex(regex_list):
     return res
 
 
-def check_start(cmd, filterstr, n_instances=1, retry=1):
+def check_start(cmd, filterstr, n_instances=1, retry=1, delay=0.5):
     """Run command (possibly multiple times) and check if it is started based on filterstr
 
     Args:
@@ -330,6 +331,8 @@ def check_start(cmd, filterstr, n_instances=1, retry=1):
             j.logger.debug(f"return code is: {rc}")
         except psutil.TimeoutExpired:
             j.logger.debug("the start command still running after 1 sec")  # still running
+        else:
+            time.sleep(delay)
         # TODO check based on command
         if check_running(filterstr, min=n_instances):
             j.logger.debug(f"found at least {n_instances} instances using the filter string: {filterstr}")
@@ -341,7 +344,7 @@ def check_start(cmd, filterstr, n_instances=1, retry=1):
     raise j.exceptions.Runtime("could not start the required number of instances.")
 
 
-def check_stop(cmd, filterstr, retry=1, n_instances=0):
+def check_stop(cmd, filterstr, retry=1, n_instances=0, delay=0.5):
     """Executes a stop command (possibly multiple times) and check if it is already stopped based on filterstr
 
     Args:
@@ -378,6 +381,8 @@ def check_stop(cmd, filterstr, retry=1, n_instances=0):
                 j.logger.debug(f"err: {error_output}")
         except psutil.TimeoutExpired:
             j.logger.debug("the start command still running after 1 sec")  # still running
+        else:
+            time.sleep(delay)
         found = get_pids(filterstr)
         if len(found) == n_instances:
             j.logger.debug(

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -1,9 +1,13 @@
 """This module execute process on system and manage them
 
-Example:
+below are some examples of the functions included in this moduke (not all inclusive.):
+
+Examples:
     ```
-    #to create a process
     >>> from jumpscale.loader import j
+    >>> import signal
+
+    #to create a process
     >>> rc, out, err = j.sals.process.execute("ls", cwd="/tmp", showout=True)
     # this executes ls command on dir "/tmp" showing output from stdout
     # rc -> contains exit status
@@ -13,11 +17,71 @@ Example:
     # checks if a process with this pid is exists in the current process list
     >>> j.sals.process.is_alive(10022)
 
+    # Checks if a specific command is available on the system
+    >>> j.sals.process.is_installed('top')
+
     # kill a process with pid 10022 with SIGTERM
     >>> j.sals.process.kill(10022)
 
-    # gets pid of the process listenning on port 8000
+    # kill a process with pid 10022 with SIGTERM, wait 3 seconds for it to disappear, then if still alive kill it with SIGKILL
+    >>> j.sals.process.kill(10022, timeout=3, sure_kill=True)
+
+    # Kill all processes that match the given name with a SIGTERM
+    >>> j.sals.process.kill_all('tail', sig=signal.SIGTERM)
+
+    # Check if there is any running process that match the given name.
+    >>> j.sals.process.ps_find('python3')
+
+    # gets pid of the process listenning on port TCP 8000 ipv4 localhost address
     >>> j.sals.process.get_pid_by_port(8000)
+
+    # gets pid of the process listenning on port UDP 8000 ipv6 localhost address
+    >>> j.sals.process.get_pid_by_port(8000, ipv6=True, udp=True)
+
+    # Returns the psutil.Process object that is listening on the given port
+    >>> j.sals.process.get_process_by_port(8000, ipv6=True, udp=True)
+
+    # Get pids of process by a filter string and sort by cpu utilization descendingly
+    >>> j.sals.process.get_pids_filtered_sorted('chrome', sort='%cpu', desc=True)
+
+    # Return a list of processes ID(s) matching the given name.
+    >>> j.sals.process.get_pids('code')
+
+    # Return a list of processes ID(s) matching the given name, including the result of matching againest the full command line.
+    >>> j.sals.process.get_pids('http.server', full_cmd_line=True)
+
+    # Return a list of processes ID(s) matching the given name, including any zombie processes
+    >>> j.sals.process.get_pids('python3', include_zombie=False)
+
+    # get processes info about top 3 processes which consumed the most memory
+    >>> j.sals.process.get_processes_info(limit=3)
+
+    # get processes info about top 3 processes which consumed the most cpu time
+    >>> j.sals.process.get_processes_info(sort='cpu_time', limit=3)
+
+    # get processes info about last process started
+    >>> j.sals.process.get_processes_info(sort='create_time', limit=1)
+
+    # get processes info sorted by pid ascending limited to 10 processes
+    >>> j.sals.process.get_processes_info(sort='pid', limit=10, desc=False)
+
+    # Kill a process and its children (including grandchildren) with SIGTERM and fallback to SIGKILL when needed
+    >>> j.sals.process.kill_proc_tree(20778, sure_kill=True)
+
+    # send SIGTERM to all processes spawned by a given process, but leave the process itself.
+    >>> j.sals.process.kill_proc_tree(20778, include_parent=False)
+
+    # Terminate a list of processes with a given list of pids, fallback to SIGKILL after 1 seconds.
+    >>> j.sals.process.kill_all_pids([3067, 7888, 10221], timeout=1, sure_kill=True)
+
+    # terminate a process that listen to a given tcp port on ipv4 address
+    >>> j.sals.process.kill_process_by_port(8000)
+
+    # terminate a process that listen to a given udp port on ipv6 address, fallback to SIGKILL after 3 sec
+    >>> j.sals.process.kill_process_by_port(8000, udp=True, ipv6=True, timeout=3, sure_kill=True)
+
+    # Terminate all processes owned by a given user name, fallback to SIGKILL when needed
+    >>> j.sals.process.kill_user_processes('sameh', sure_kill=True)
     ```
 """
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -432,7 +432,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
             if (
                 (match_predicate(process_name, proc.info["name"]))
                 or (proc.info["exe"] and match_predicate(process_name, os.path.basename(proc.info["exe"])))
-                or (proc.info["cmdline"] and match_predicate(process_name, os.path.basename(proc.info["cmdline"])))
+                or (proc.info["cmdline"] and match_predicate(process_name, proc.info["cmdline"]))
             ):
                 pids.append(proc.pid)
                 # return early if no need to iterate over all running process

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -633,7 +633,7 @@ def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None,
     for pid in pids:
         try:
             kill(pid, sig, timeout=timeout, sure_kill=sure_kill)
-        except (j.exceptions.Runtime, j.exceptions.Permission) as e:
+        except (j.exceptions.Runtime, j.exceptions.Permission):
             failed_processes.append(pid)
     return failed_processes or None  # return None if the failed list is empty
 
@@ -792,7 +792,7 @@ def get_processes_info(user=None, sort="mem", filterstr=None, limit=25, desc=Tru
         else:
             try:
                 return procObj[sort]
-            except KeyError as e:
+            except KeyError:
                 j.logger.error(f"bad field name for sorting: {sort}")
                 raise j.exceptions.Value(f"bad field name for sorting: {sort}")
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -419,6 +419,8 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
     # default match predicate
     def default_predicate(target, given):
         j.logger.debug(f"matching {target} with {given}")
+        if isinstance(given, list):
+            return target.strip().lower() in given
         return target.strip().lower() == given.lower()
 
     match_predicate = match_predicate or default_predicate
@@ -430,7 +432,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
             if (
                 (match_predicate(process_name, proc.info["name"]))
                 or (proc.info["exe"] and match_predicate(process_name, os.path.basename(proc.info["exe"])))
-                or (proc.info["cmdline"] and match_predicate(process_name, os.path.basename(proc.info["cmdline"][0])))
+                or (proc.info["cmdline"] and match_predicate(process_name, os.path.basename(proc.info["cmdline"])))
             ):
                 pids.append(proc.pid)
                 # return early if no need to iterate over all running process

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -417,6 +417,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
     """
     # default match predicate
     def default_predicate(target, given):
+        j.logger.debug(f"matching {target} with {given}")
         return target.strip().lower() == given.lower()
 
     match_predicate = match_predicate or default_predicate
@@ -424,12 +425,11 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
     pids = []
     for proc in psutil.process_iter(["name", "exe", "cmdline"]):
         try:
+            j.logger.debug(f"process to check: {proc.info}")
             if (
-                match_predicate(process_name, proc.info["name"])
-                or proc.info["exe"]
-                and match_predicate(process_name, os.path.basename(proc.info["exe"]))
-                or proc.info["cmdline"]
-                and match_predicate(process_name, os.path.basename(proc.info["cmdline"][0]))
+                (match_predicate(process_name, proc.info["name"]))
+                or (proc.info["exe"] and match_predicate(process_name, os.path.basename(proc.info["exe"])))
+                or (proc.info["cmdline"] and match_predicate(process_name, os.path.basename(proc.info["cmdline"][0])))
             ):
                 pids.append(proc.pid)
                 # return early if no need to iterate over all running process

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -750,15 +750,16 @@ def kill_process_by_port(port, ipv6=False, udp=False, sig=signal.SIGTERM, timeou
         ipv6 (bool, optional): Whether to search the connections that using ipv6 instead of ipv4. Defaults to False.
         udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
         sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
-        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception
             or, if sure_kill=True, send a SIGKILL. Defaults to 5.
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
-    Returns:
-        None
+    Raises:
+        j.exceptions.Runtime: In case killing the process failed.
+        j.exceptions.Permission: In case the permission to perform this action is denied.
     """
     proc = get_process_by_port(port, ipv6=ipv6, udp=udp)
-    return kill(proc, sig=sig, timeout=timeout, sure_kill=sure_kill)
+    kill(proc, sig=sig, timeout=timeout, sure_kill=sure_kill)
 
 
 def is_port_listening(port, ipv6=False):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -191,7 +191,7 @@ def kill_all(process_name, sig=signal.SIGKILL):
     return failed_processes
 
 
-def get_pids_filtered_sorted(filterstr, sortkey=None):
+def get_pids_filtered_sorted(filterstr, sortkey=None, desc=False):
     """Get pids of process by a filter string and optionally sort by sortkey
 
     Args:
@@ -210,6 +210,7 @@ def get_pids_filtered_sorted(filterstr, sortkey=None):
             ppid           parent process ID.
             psr            processor that process is currently assigned to.
             start_time     starting time or date of the process.
+        desc: (bool, optional): Defaults to False.
 
     Returns:
         list(int): processes pids
@@ -230,9 +231,6 @@ def get_pids_filtered_sorted(filterstr, sortkey=None):
     }
     if sortkey is None:  # mimic default ps commnad sorting behavior
         sortkey = "pid"
-        desc = False
-    else:
-        desc = True
     # return pids from process objects
     return [p["pid"] for p in get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)]
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -310,32 +310,26 @@ def get_filtered_pids(filterstr, excludes=None):
         list of int: list of the processes IDs
     """
     pids = []
-    try:
-        for proc in psutil.process_iter(["name", "cmdline"]):
-            cmd_line = " ".join(proc.info["cmdline"])
-            if proc.info["cmdline"] and filterstr in cmd_line:
-                j.logger.debug(f"found filter string: {filterstr} in command line: {cmd_line}")
-                if excludes:
-                    for exclude in excludes:
-                        if exclude in cmd_line:
-                            j.logger.debug(
-                                f"but excluded because it contain exclude string: {exclude} in command line: {cmd_line}"
-                            )
-                            break
-                    else:  # intended `for/else` meaning for loop finished normally with no break
-                        pids.append(proc.pid)  # may yield proc instead
-                    continue
-                else:
+    for proc in psutil.process_iter(["name", "cmdline"]):
+        cmd_line = " ".join(proc.info["cmdline"])
+        if proc.info["cmdline"] and filterstr in cmd_line:
+            j.logger.debug(f"found filter string: {filterstr} in command line: {cmd_line}")
+            if excludes:
+                for exclude in excludes:
+                    if exclude in cmd_line:
+                        j.logger.debug(
+                            f"but excluded because it contain exclude string: {exclude} in command line: {cmd_line}"
+                        )
+                        break
+                else:  # intended `for/else` meaning for loop finished normally with no break
                     pids.append(proc.pid)  # may yield proc instead
-        j.logger.debug(
-            f"founded pids are: {pids}"
-            if pids
-            else f"filter string {filterstr} not found in any processes. root needed?"
-        )
-        return pids
-    except (psutil.AccessDenied, psutil.NoSuchProcess) as e:
-        j.logger.exception("exception occurred while iterating over the system processes", exception=e)
-        pass
+                continue
+            else:
+                pids.append(proc.pid)  # may yield proc instead
+    j.logger.debug(
+        f"founded pids are: {pids}" if pids else f"filter string {filterstr} not found in any processes. root needed?"
+    )
+    return pids
 
 
 def get_pids_filtered_by_regex(regex_list):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -286,7 +286,7 @@ def get_filtered_pids(filterstr, excludes=None):
         excludes (list[str]): exclude list. Defaults to None.
 
     Returns:
-        list of int: list of the processes IDs
+        list of int: List of the processes IDs
     """
     pids = []
     for proc in psutil.process_iter(["name", "cmdline"]):
@@ -457,7 +457,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None, incl
             if full_cmd_line is set to True, the full command line is used. Defaults to False.
 
     Returns:
-        list of int: list of PID(s)
+        list of int: List of the processes IDs.
     """
     # default match predicate
     def default_predicate(target, given):
@@ -502,7 +502,7 @@ def get_my_process():
     """Get psutil.Process object of the current process.
 
     Returns:
-        (psutil.Process): psutil.Process object of the current process.
+        psutil.Process: Process object of the current process.
     """
     return get_process_object(os.getpid(), die=True)
 
@@ -520,7 +520,7 @@ def get_process_object(pid, die=False):
         psutil.AccessDenied: If permission denied.
 
     Returns:
-        psutil.Process or None: psutil.Process object if he given PID is found, None otherwise.
+        psutil.Process or None: The Process object of the given PID if found, otherwise None, if die set to False.
     """
     try:
         return psutil.Process(pid)
@@ -660,7 +660,7 @@ def get_pid_by_port(port, ipv6=False, udp=False):
         udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
 
     Returns:
-        (int or None): Process ID that listen on that port
+        int or None: PID for the proceses that listen on that port.
     """
 
     process = get_process_by_port(port, ipv6=ipv6, udp=udp)
@@ -682,7 +682,7 @@ def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None,
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        None or list of int: represents the IDs of the processes remaning alive.
+        None or list of int: a list of PIDs that represents the processes remaning alive if any, otherwise None.
     """
     pids = get_pids(process_name, match_predicate=match_predicate)
     failed_processes = []
@@ -1022,7 +1022,7 @@ def kill_proc_tree(
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        (list[psutil.Process] or None): list of process objects that remain alive if any. None otherwise.
+        list of psutil.Process or None: list of process objects that remain alive if any. None otherwise.
     """
     if isinstance(parent, int):
         parent = get_process_object(parent)

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -579,11 +579,13 @@ def get_user_processes(user):
         pass
 
 
-def kill_user_processes(user, sure_kill=False):
+def kill_user_processes(user, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     """Kill all processes for a specific user.
 
     Args:
         user (str): The user name to match against.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception or, if sure_kill=True, send a SIGKILL. Defaults to 5.
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
@@ -592,7 +594,7 @@ def kill_user_processes(user, sure_kill=False):
     failed_processes = []
     for proc in get_user_processes(user):
         try:
-            kill(proc, sure_kill=sure_kill)
+            kill(proc, sig=sig, timeout=timeout, sure_kill=sure_kill)
         except (j.exceptions.Runtime, j.exceptions.Permission) as e:
             j.logger.exception("ignoring an exception that occurred while iterating over user processes", exception=e)
             failed_processes.append(proc)

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -234,7 +234,7 @@ def get_pids_filtered_sorted(filterstr, sortkey=None):
     else:
         desc = True
     # return pids from process objects
-    return [p.pid for p in get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)]
+    return [p["pid"] for p in get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)]
 
 
 def get_filtered_pids(filterstr, excludes=None):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -419,8 +419,6 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
     # default match predicate
     def default_predicate(target, given):
         j.logger.debug(f"matching {target} with {given}")
-        if isinstance(given, list):
-            return target.strip().lower() in given
         return target.strip().lower() == given.lower()
 
     match_predicate = match_predicate or default_predicate
@@ -432,7 +430,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None):
             if (
                 (match_predicate(process_name, proc.info["name"]))
                 or (proc.info["exe"] and match_predicate(process_name, os.path.basename(proc.info["exe"])))
-                or (proc.info["cmdline"] and match_predicate(process_name, proc.info["cmdline"]))
+                or (proc.info["cmdline"] and match_predicate(process_name, os.path.basename(proc.info["cmdline"][0])))
             ):
                 pids.append(proc.pid)
                 # return early if no need to iterate over all running process

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -444,6 +444,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None, incl
                 )
             ):
                 pids.append(proc.pid)
+                j.logger.debug(f"process {len(pids) }found: {proc.info}")
                 # return early if no need to iterate over all running process
                 if limit and len(pids) == limit:
                     return pids

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -559,7 +559,7 @@ def kill_user_processes(user, sig=signal.SIGTERM, timeout=5, sure_kill=False):
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        list of psutil.Process or None): list of process objects that remain alive if any. None otherwise.
+        list of psutil.Process): list of process objects that remain alive if any.
     """
     failed_processes = []
     for proc in get_user_processes(user):
@@ -573,7 +573,7 @@ def kill_user_processes(user, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     if failed_processes:
         gone, failed_processes = psutil.wait_procs(failed_processes, timeout=0)
 
-    return failed_processes or None  # return None if the failed list is empty
+    return failed_processes
 
 
 def get_similar_processes(target_proc=None):
@@ -682,7 +682,7 @@ def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None,
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        None or list of int: a list of PIDs that represents the processes remaning alive if any, otherwise None.
+        list of int: represents the IDs of the processes remaning alive if any.
     """
     pids = get_pids(process_name, match_predicate=match_predicate)
     failed_processes = []
@@ -691,7 +691,7 @@ def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None,
             kill(pid, sig, timeout=timeout, sure_kill=sure_kill)
         except (j.exceptions.Runtime, j.exceptions.Permission):
             failed_processes.append(pid)
-    return failed_processes or None  # return None if the failed list is empty
+    return failed_processes
 
 
 def kill_all_pids(pids, sig=signal.SIGTERM, timeout=5, sure_kill=False):
@@ -706,7 +706,7 @@ def kill_all_pids(pids, sig=signal.SIGTERM, timeout=5, sure_kill=False):
 
 
     Returns:
-        None or list of int: represents the IDs of the processes remaning alive.
+        list of int: represents the IDs of the processes remaning alive if any.
     """
     failed_processes = []
     for pid in pids:
@@ -714,7 +714,7 @@ def kill_all_pids(pids, sig=signal.SIGTERM, timeout=5, sure_kill=False):
             kill(pid, sig, timeout=timeout, sure_kill=sure_kill)
         except (j.exceptions.Runtime, j.exceptions.Permission):
             failed_processes.append(pid)
-    return failed_processes or None  # return None if the failed list is empty
+    return failed_processes
 
 
 def kill_process_by_port(port, ipv6=False, udp=False, sig=signal.SIGTERM, timeout=5, sure_kill=False):
@@ -1026,7 +1026,7 @@ def kill_proc_tree(
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        list of psutil.Process or None: list of process objects that remain alive if any. None otherwise.
+        list of psutil.Process: represents the objects of the processes remaning alive if any.
     """
     if isinstance(parent, int):
         parent = get_process_object(parent)
@@ -1052,7 +1052,7 @@ def kill_proc_tree(
     # making sure
     if failed:
         gone, failed = psutil.wait_procs(failed, timeout=0)
-    return failed or None
+    return failed
 
 
 def in_docker():

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -454,7 +454,7 @@ def check_stop(cmd, filterstr, retry=1, n_instances=0, timeout=2, delay=0.5):
             j.logger.debug(
                 f"the required {n_instances} matching the instances found using the filter string: {filterstr}"
             )
-            return True  # should remove? None
+            return
         else:
             j.logger.debug(
                 f"the required {n_instances} not matching the instances number found using the filter string: {filterstr} yet"

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -1,6 +1,6 @@
 """This module execute process on system and manage them
 
-below are some examples of the functions included in this moduke (not all inclusive.):
+below are some examples of the functions included in this module (not all inclusive.):
 
 Examples:
     ```
@@ -85,12 +85,13 @@ Examples:
 
 import math
 import os
-import time
-import subprocess
-import shlex
 import re
+import shlex
 import signal
+import subprocess
+import time
 from collections import defaultdict
+
 import psutil
 from jumpscale.loader import j
 
@@ -187,7 +188,6 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
         # If timeout exceeded and the process is still alive raise TimeoutExpired exception
         proc.wait(timeout=timeout)
         j.logger.debug(f"the process with PID: {proc.pid} was terminated with sig: {sig}.")
-        return
     except psutil.TimeoutExpired as e:
         # timeout expires and process is still alive.
         if sure_kill and sig != signal.SIGKILL and os.name != "nt":
@@ -208,7 +208,6 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
                 j.logger.debug("the process may be in an uninterruptible sleep.")
                 j.logger.warning(f"Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}")
                 raise j.exceptions.Runtime(f"Could not kill process with pid {proc.pid}, {proc.status()}") from e
-            return
         else:
             j.logger.warning(f"Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}")
             raise j.exceptions.Runtime(f"Could not kill process with pid {proc.pid}") from e
@@ -219,7 +218,6 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     except psutil.NoSuchProcess:
         # Process no longer exists or Zombie (already dead)
         j.logger.debug("Process is no longer exists or a Zombie (already dead)")
-        return
 
 
 def ps_find(process_name):
@@ -643,7 +641,7 @@ def set_env_var(var_names, var_values):
     Raises:
         j.exceptions.RuntimeError: if error happened during setting the environment variables
     """
-    # XXX Note:
+    # Note:
     # On some platforms, including FreeBSD and Mac OS X, setting environ may cause memory leaks.
     # https://docs.python.org/3/library/os.html?highlight=os%20environ#os.environ
     # Refer to the system documentation for putenv().
@@ -772,7 +770,7 @@ def get_process_by_port(port, ipv6=False, udp=False):
     """
     for conn in psutil.net_connections():  # TODO use kind parameter
         try:
-            # XXX should we check against ESTABLISHED status?
+            # should we check against ESTABLISHED status?
             # connection.status For UDP and UNIX sockets this is always going to be psutil.CONN_NONE
             if (
                 conn.laddr.port == port
@@ -884,7 +882,7 @@ def get_processes_info(user=None, sort="mem", filterstr=None, limit=25, desc=Tru
         else:
             p_source = get_processes()
     else:
-        # XXX it makes sense that get_pids func should returns list of psutil.Process objects instead of list of pids
+        # it makes sense that get_pids func should returns list of psutil.Process objects instead of list of pids
         if user:
             p_source = map(get_process_object, get_pids(process_name=filterstr, _alt_source=get_user_processes(user)))
         else:
@@ -1033,9 +1031,9 @@ def kill_proc_tree(
         if parent is None:
             return  # already die
 
-    # XXX should be checked on any killing function
-    # XXX here we first need to make sure taht `include_parent` is True
-    # XXX and/or better check inside the below for loop
+    # should be checked on any killing function
+    # here we first need to make sure taht `include_parent` is True
+    # and/or better check inside the below for loop
     assert parent.pid != os.getpid(), "won't kill myself"
 
     processes = parent.children(recursive=include_grand_children)[::-1]

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -233,7 +233,8 @@ def get_pids_filtered_sorted(filterstr, sortkey=None):
         desc = False
     else:
         desc = True
-    return get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)
+    # return pids from process objects
+    return [p.pid for p in get_processes_info(sort=ps_to_psutil_map[sortkey], filterstr=filterstr, desc=desc)]
 
 
 def get_filtered_pids(filterstr, excludes=None):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -26,9 +26,6 @@ Examples:
     # kill a process with pid 10022 with SIGTERM, wait 3 seconds for it to disappear, then if still alive kill it with SIGKILL
     >>> j.sals.process.kill(10022, timeout=3, sure_kill=True)
 
-    # Kill all processes that match the given name with a SIGTERM
-    >>> j.sals.process.kill_all('tail', sig=signal.SIGTERM)
-
     # Check if there is any running process that match the given name.
     >>> j.sals.process.ps_find('python3')
 
@@ -235,24 +232,6 @@ def ps_find(process_name):
         bool: True if process is found, False otherwise.
     """
     return len(get_pids(process_name, limit=1)) == 1
-
-
-def kill_all(process_name, sig=signal.SIGKILL):
-    """Kill all processes that match 'process_name'.
-
-    use kill_process_by_name is preferred.
-
-    Args:
-        process_name (str): The target process name
-        sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL
-
-    Returns:
-        None or list of int: a list represents the IDs of the processes remaning alive, otherwise None.
-    """
-    # XXX kill default to SIGTERM while kill_all default to SIGKILL (inconsistency)?
-    # XXX almost like kill_process_by_name
-    failed_processes = kill_process_by_name(process_name, sig)
-    return failed_processes
 
 
 def get_pids_filtered_sorted(filterstr, sortkey=None, desc=False):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -754,7 +754,24 @@ def get_processes_info(user=None, sort="mem", filterstr=None, limit=25, desc=Tru
         desc (bool, optional): whether to sort the data returned in descending order or not. Defaults to True.
 
     Returns:
-        list[psutil.Process]: processes objects
+        dict: processes info as a dictionary
+            available keys [
+                    "cpu_num",
+                    "cpu_percent",
+                    "cpu_times",
+                    "create_time",
+                    "gids",
+                    "memory_percent",
+                    "name",
+                    "pid",
+                    "ppid",
+                    "status",
+                    "uids",
+                    "username",
+                    "rss",
+                    "cpu_time",
+                    "ports"
+                ]
     """
 
     def _get_sort_key(procObj):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -902,14 +902,16 @@ def get_processes_info(user=None, sort="mem", filterstr=None, limit=25, desc=Tru
 
     processes_list = []
     if not filterstr:
-        p_source = get_processes() if not user else get_user_processes(user=user)
+        if user:
+            p_source = get_user_processes(user=user)
+        else:
+            p_source = get_processes()
     else:
         # XXX it makes sense that get_pids func should returns list of psutil.Process objects instead of list of pids
-        p_source = (
-            map(get_process_object, get_pids(process_name=filterstr))
-            if not user
-            else map(get_process_object, get_pids(process_name=filterstr, _alt_source=get_user_processes(user)))
-        )
+        if user:
+            p_source = map(get_process_object, get_pids(process_name=filterstr, _alt_source=get_user_processes(user)))
+        else:
+            p_source = map(get_process_object, get_pids(process_name=filterstr))
     for proc in p_source:
         try:
             # Fetch process details as dict

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -722,6 +722,29 @@ def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None,
     return failed_processes or None  # return None if the failed list is empty
 
 
+def kill_all_pids(pids, sig=signal.SIGTERM, timeout=5, sure_kill=False):
+    """Kill all processes with given pids.
+
+    Args:
+        pids (list of int): The target processes IDs.
+        sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
+
+
+    Returns:
+        None or list of int: represents the IDs of the processes remaning alive.
+    """
+    failed_processes = []
+    for pid in pids:
+        try:
+            kill(pid, sig, timeout=timeout, sure_kill=sure_kill)
+        except (j.exceptions.Runtime, j.exceptions.Permission):
+            failed_processes.append(pid)
+    return failed_processes or None  # return None if the failed list is empty
+
+
 def kill_process_by_port(port, ipv6=False, udp=False, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     """Kill process by port.
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -358,20 +358,40 @@ def check_stop(cmd, filterstr, retry=1, n_instances=0):
         if isinstance(cmd, str):
             cmd = cmd.split()
         proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        j.logger.debug(f"attempt no: {i}")
+        j.logger.debug(f"executed cmd: {cmd}")
+        j.logger.debug(f"proc.cmdline: {proc.cmdline()}")
+        j.logger.debug(f"pid: {proc.pid}")
+        j.logger.debug(f"status: {proc.status()}")
+        j.logger.debug(f"name: {proc.name()}")
+        j.logger.debug(f"exe: {proc.exe()}")
+        j.logger.debug(f"children: {proc.children(recursive=True)}")
+        j.logger.debug(f"parents: {proc.parents()}")
         try:
             rc = proc.wait(timeout=5)  # makesure the process is stable
             # print(f'rc: {rc}')
             if rc == 0:
-                pass  # executing the process succeeded but exited immediately!
+                # executing the process succeeded but exited immediately!
+                j.logger.debug("executing the stop command succeeded but exited immediately")
             else:
-                pass  # the process exited with error
+                # the process exited with error
+                j.logger.debug("the stop command exited with error")  # the process exited with error
         except psutil.TimeoutExpired:
-            pass  # still running
+            j.logger.debug("the start command still running after 1 sec")  # still running
         found = get_pids(filterstr)
         if len(found) == n_instances:
+            j.logger.debug(
+                f"the required {n_instances} matching the instances found using the filter string: {filterstr}"
+            )
             return True  # should remove? None
         else:
+            j.logger.debug(
+                f"the required {n_instances} not matching the instances number found using the filter string: {filterstr} yet"
+            )
             continue
+    j.logger.error(f"could not match the required number of instances ({n_instances}) after {i} attempts.")
+    j.logger.debug(f"alive: {found}")
+    j.logger.debug(f"{len(found)}")
     raise j.exceptions.Runtime(f"could not stop {cmd}, found {len(found)} of instances instead of {n_instances}")
 
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -25,6 +25,7 @@ Example:
 import math
 import os
 import subprocess
+import shlex
 import re
 import signal
 from collections import defaultdict
@@ -48,7 +49,7 @@ def execute(
     Accepts command as a list too, with auto-escaping.
 
     Args:
-        cmd (str/list[str]): Command to be executed, e.g. "ls -la" or ["ls", "-la"]
+        cmd (str or list of str): Command to be executed, e.g. "ls -la" or ["ls", "-la"]
         showout (bool, optional): Whether to show stdout of the command or not. Defaults to False.
         cwd (str, optional): Path to `cd` into before running command. Defaults to None.
         shell (str, optional): Specify a working directory for the command. Defaults to "/bin/bash".
@@ -103,7 +104,7 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     """Kill a process with a specified signal.
 
     Args:
-        proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.
+        proc (int or psutil.Process): Target process ID (PID) or psutil.Process object.
         sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
         timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
             or, if sure_kill=True, send a SIGKILL. Defaults to 5.
@@ -298,7 +299,7 @@ def check_start(cmd, filterstr, n_instances=1, retry=1):
     """Run command (possibly multiple times) and check if it is started based on filterstr
 
     Args:
-        cmd (str/list): Command to be executed.
+        cmd (str or list of str): Command to be executed.
         filterstr (str): Filter string. will match against against Process.name(),\
             Process.exe() and Process.cmdline()
         n_instances (int, optional): Number of needed instances. Defaults to 1.
@@ -309,8 +310,8 @@ def check_start(cmd, filterstr, n_instances=1, retry=1):
     """
     for i in range(retry):
         if isinstance(cmd, str):
-            cmd = cmd.split()
-        proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+            args = shlex.split(cmd)
+        proc = psutil.Popen(args, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         j.logger.debug(f"attempt no: {i}")
         j.logger.debug(f"executed cmd: {cmd}")
         j.logger.debug(f"proc.cmdline: {proc.cmdline()}")
@@ -353,8 +354,8 @@ def check_stop(cmd, filterstr, retry=1, n_instances=0):
 
     for i in range(retry):
         if isinstance(cmd, str):
-            cmd = cmd.split()
-        proc = psutil.Popen(cmd, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+            args = shlex.split(cmd)
+        proc = psutil.Popen(args, close_fds=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         j.logger.debug(f"attempt no: {i}")
         j.logger.debug(f"executed cmd: {cmd}")
         j.logger.debug(f"proc.cmdline: {proc.cmdline()}")
@@ -510,7 +511,7 @@ def kill_user_processes(user, sure_kill=False):
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        (list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.
+        (list[psutil.Process] or None): list of process objects that remain alive if any. None otherwise.
     """
     failed_processes = []
     for proc in get_user_processes(user):
@@ -607,7 +608,7 @@ def get_pid_by_port(port, ipv6=False, udp=False):
         udp (bool, optional): Whether to search the connections for UDP port instead of TCP. Defaults to False.
 
     Returns:
-        (int/None): Process ID that listen on that port
+        (int or None): Process ID that listen on that port
     """
 
     process = get_process_by_port(port, ipv6=ipv6, udp=udp)
@@ -931,7 +932,7 @@ def kill_proc_tree(
     """Kill a process and its children (including grandchildren) with signal `sig`
 
     Args:
-        proc (int/psutil.Process): Target process ID (PID) or psutil.Process object.
+        proc (int or psutil.Process): Target process ID (PID) or psutil.Process object.
         sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
         include_parent (): Whether to kill the process itself. Defaults to True.
         include_grand_children (): whether to kill recursively all grandchildren. Defaults to True.
@@ -940,7 +941,7 @@ def kill_proc_tree(
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        (list[psutil.Process]/None): list of process objects that remain alive if any. None otherwise.
+        (list[psutil.Process] or None): list of process objects that remain alive if any. None otherwise.
     """
     if isinstance(parent, int):
         try:

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -536,10 +536,10 @@ def get_user_processes(user):
     """Get all process for a specific user.
 
     Args:
-        user (str): Te user name to match against.
+        user (str): The user name to match against.
 
     Yields:
-        psutil.Process: psutil.Process object for all processes owned by `user`.
+        psutil.Process: process object for all processes owned by `user`.
     """
     try:
         for process in psutil.process_iter(["name", "exe", "cmdline"]):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -634,18 +634,21 @@ def check_process_for_pid(pid, process_name):
 def set_env_var(var_names, var_values):
     """Set the value of the environment variables {varnames}. Existing variable are overwritten
 
+    Such changes to the environment affect subprocesses started with os.system(), popen() or fork() and execv()
+
     Args:
-        var_names list[str]: A list of the names of all the environment variables to set
-        varvalues list[str]: A list of all values for the environment variables
+        var_names (list of str): A list of the names of all the environment variables to set
+        varvalues (list of str): A list of all values for the environment variables
 
     Raises:
         j.exceptions.RuntimeError: if error happened during setting the environment variables
     """
-    try:
-        for i in range(len(var_names)):
-            os.environ[var_names[i]] = str(var_values[i]).strip()
-    except Exception as e:
-        raise j.exceptions.RuntimeError(e)
+    # XXX Note:
+    # On some platforms, including FreeBSD and Mac OS X, setting environ may cause memory leaks.
+    # https://docs.python.org/3/library/os.html?highlight=os%20environ#os.environ
+    # Refer to the system documentation for putenv().
+    for i in range(len(var_names)):
+        os.environ[var_names[i]] = str(var_values[i]).strip()
 
 
 def get_pid_by_port(port, ipv6=False, udp=False):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -406,6 +406,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None, incl
             of the psutil.Process objects to match against.
             ex: get_user_processes func, or get_similar_processes.
             if not specified, psutil.process_iter will be used. Defaults to None.
+        include_zombie (bool, optional): Whether to include pid for zombie proccesses or not. Defaults to False.
 
     Returns:
         list[int]: list of PID(s)

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -178,22 +178,19 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     Raises:
         j.exceptions.Runtime: In case killing the process failed.
         j.exceptions.Permission: In case the permission to perform this action is denied.
-
-    Returns:
-        None
     """
     try:
         if isinstance(proc, int):
             proc = get_process_object(proc)
         if proc.status() == psutil.STATUS_ZOMBIE:
-            return True
+            return
         proc.send_signal(sig)
         # Wait for a process to terminate
         # If PID no longer exists return None immediately
         # If timeout exceeded and the process is still alive raise TimeoutExpired exception
         proc.wait(timeout=timeout)
         j.logger.debug(f"the process with PID: {proc.pid} was terminated with sig: {sig}.")
-        return True  # XXX only to pass current tests
+        return
     except psutil.TimeoutExpired as e:
         # timeout expires and process is still alive.
         if sure_kill and sig != signal.SIGKILL and os.name != "nt":
@@ -209,12 +206,12 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
                     j.logger.debug(
                         f"the process with PID: {proc.pid} becomes a zombie and should be considered a dead."
                     )
-                    return True
+                    return
                 # the process may be in an uninterruptible sleep
                 j.logger.debug("the process may be in an uninterruptible sleep.")
                 j.logger.warning(f"Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}")
                 raise j.exceptions.Runtime(f"Could not kill process with pid {proc.pid}, {proc.status()}") from e
-            return True  # XXX only to pass current tests
+            return
         else:
             j.logger.warning(f"Could not kill the process with pid: {proc.pid} with {sig}. Timeout: {timeout}")
             raise j.exceptions.Runtime(f"Could not kill process with pid {proc.pid}") from e
@@ -225,7 +222,7 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     except (psutil.ZombieProcess, psutil.NoSuchProcess):
         # Process no longer exists or Zombie (already dead)
         j.logger.debug("Process is no longer exists or a Zombie (already dead)")
-        return True
+        return
 
 
 def ps_find(process_name):

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -325,6 +325,8 @@ def check_start(cmd, filterstr, n_instances=1, retry=1):
                 j.logger.debug("executing the start command succeeded but exited immediately")
             else:
                 j.logger.debug("the start command exited with error")  # the process exited with error
+                output, error_output = proc.communicate()
+                j.logger.debug(f"err: {error_output}")
             j.logger.debug(f"return code is: {rc}")
         except psutil.TimeoutExpired:
             j.logger.debug("the start command still running after 1 sec")  # still running
@@ -372,6 +374,8 @@ def check_stop(cmd, filterstr, retry=1, n_instances=0):
             else:
                 # the process exited with error
                 j.logger.debug("the stop command exited with error")  # the process exited with error
+                output, error_output = proc.communicate()
+                j.logger.debug(f"err: {error_output}")
         except psutil.TimeoutExpired:
             j.logger.debug("the start command still running after 1 sec")  # still running
         found = get_pids(filterstr)

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -399,7 +399,7 @@ def check_start(cmd, filterstr, n_instances=1, retry=1, timeout=2, delay=0.5):
         # TODO check based on command
         if check_running(filterstr, min=n_instances):
             j.logger.debug(f"found at least {n_instances} instances using the filter string: {filterstr}")
-            return True  # XXX should remove? None
+            return
         else:
             j.logger.debug(f"the required number of instances using the filter string: {filterstr} not found yet!")
             continue

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -429,7 +429,7 @@ def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None, incl
     pids = []
     for proc in p_source:
         try:
-            if proc.status() == psutil.STATUS_ZOMBIE and not include_zombie:
+            if not include_zombie and proc.status() == psutil.STATUS_ZOMBIE:
                 j.logger.debug(f"ignoring : {proc.pid} zombie process.")
                 continue
             if (

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -594,7 +594,6 @@ def kill_user_processes(user, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     if failed_processes:
         gone, failed_processes = psutil.wait_procs(failed_processes, timeout=0)
 
-    j.logger.debug(f"stay alive: {len(failed_processes)}, pids -> {[p.pid for p in failed_processes]}")
     return failed_processes or None  # return None if the failed list is empty
 
 

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -171,7 +171,7 @@ def kill(proc, sig=signal.SIGTERM, timeout=5, sure_kill=False):
     Args:
         proc (int or psutil.Process): Target process ID (PID) or psutil.Process object.
         sig (signal, optional): See signal module constants. Defaults to signal.SIGTERM.
-        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception
             or, if sure_kill=True, send a SIGKILL. Defaults to 5.
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
@@ -232,8 +232,7 @@ def ps_find(process_name):
     """Check if there is any running process that match the given name.
 
     Args:
-        process_name (str): The target process name. will match against against Process.name(),\
-            Process.exe() and Process.cmdline()
+        process_name (str): The target process name. will match against against Process.name(), Process.exe() and Process.cmdline()
 
     Returns:
         bool: True if process is found, False otherwise.
@@ -244,12 +243,14 @@ def ps_find(process_name):
 def kill_all(process_name, sig=signal.SIGKILL):
     """Kill all processes that match 'process_name'.
 
+    use kill_process_by_name is preferred.
+
     Args:
         process_name (str): The target process name
         sig (signal, optional): See signal module constants. Defaults to signal.SIGKILL
 
     Returns:
-        None or list[int] represents the IDs of the processes remaning alive.
+        None or list of int: a list represents the IDs of the processes remaning alive, otherwise None.
     """
     # XXX kill default to SIGTERM while kill_all default to SIGKILL (inconsistency)?
     # XXX almost like kill_process_by_name
@@ -262,7 +263,7 @@ def get_pids_filtered_sorted(filterstr, sortkey=None, desc=False):
 
     Args:
         filterstr (str): filter string.
-        sortkey (str, optional): Defaults to None. (if no sortkey used it will sort by pid(s) ascending).
+        sortkey (str, optional): Defaults to None. (if no sortkey used it will sort by pid(s) in ascending order).
             sortkey can be one of the following:
             %cpu           cpu utilization of the process in
             %mem           ratio of the process's resident set size  to the physical memory on the machine, expressed as a percentage.
@@ -276,10 +277,10 @@ def get_pids_filtered_sorted(filterstr, sortkey=None, desc=False):
             ppid           parent process ID.
             psr            processor that process is currently assigned to.
             start_time     starting time or date of the process.
-        desc: (bool, optional): Defaults to False.
+        desc: (bool, optional): Whether to sort the processes in descending order or not(asc). Defaults to False (asc).
 
     Returns:
-        list(int): processes pids
+        list of int: list of the processes IDs
     """
     ps_to_psutil_map = {
         "%cpu": "cpu_percent",
@@ -302,14 +303,14 @@ def get_pids_filtered_sorted(filterstr, sortkey=None, desc=False):
 
 
 def get_filtered_pids(filterstr, excludes=None):
-    """Get pids filtered by filterstr and excludes
+    """Get pids filtered by filterstr and excludes, matching against the full command line used to start the process.
 
     Args:
         filterstr (str): the String to filter based on.
         excludes (list[str]): exclude list. Defaults to None.
 
     Returns:
-        list[int]: list of pids
+        list of int: list of the processes IDs
     """
     pids = []
     try:
@@ -342,13 +343,13 @@ def get_filtered_pids(filterstr, excludes=None):
 
 
 def get_pids_filtered_by_regex(regex_list):
-    """Get pids of a process filtered by Regex list
+    """Get pids of a process filtered by Regex list, matching against the full command line used to start the process.
 
     Args:
         regex_list (list[str]): List of regex expressions.
 
     Returns:
-        list(int): List of pids.
+        list of int: List of the processes IDs.
     """
     res = []
     for process in psutil.process_iter(attrs=["cmdline"]):
@@ -365,8 +366,7 @@ def check_start(cmd, filterstr, n_instances=1, retry=1, delay=0.5):
 
     Args:
         cmd (str or list of str): Command to be executed.
-        filterstr (str): Filter string. will match against against Process.name(),\
-            Process.exe() and Process.cmdline()
+        filterstr (str): Filter string. will match against against Process.name(), Process.exe() and Process.cmdline()
         n_instances (int, optional): Number of needed instances. Defaults to 1.
         retry (int, optional): Number of retries to execute the command and check. Defaults to 1.
 
@@ -465,27 +465,24 @@ def check_stop(cmd, filterstr, retry=1, n_instances=0, delay=0.5):
 
 
 def get_pids(process_name, match_predicate=None, limit=0, _alt_source=None, include_zombie=False, full_cmd_line=False):
-    """Return a list of processes ID(s) matching 'process_name'.
+    """Return a list of processes ID(s) matching a given process name.
 
     Function will check string against Process.name(), Process.exe() and Process.cmdline()
 
     Args:
         process_name (str): The target process name
-        match_predicate (callable, optional): Function that does matching between\
-            found processes and the targeted process, the function should accept\
-            two arguments and return a boolean. Defaults to None.
-        limit (int, optional): If not equal to 0, function will return as fast as the number\
-            of PID(s) found become equal to `limit` value.
-        _alt_source(callable or iterable, optional): Can be used to specify an alternative source\
-            of the psutil.Process objects to match against.
+        match_predicate (callable, optional): Function that does matching between found processes and the targeted process.
+            the function should accept two arguments and return a boolean. Defaults to None.
+        limit (int, optional): If not equal to 0, function will return as fast as the number of PID(s) found become equal to `limit` value.
+        _alt_source(callable or iterable, optional): Can be used to specify an alternative source of the psutil.Process objects to match against.
             ex: get_user_processes func, or get_similar_processes.
             if not specified, psutil.process_iter will be used. Defaults to None.
         include_zombie (bool, optional): Whether to include pid for zombie proccesses or not. Defaults to False.
         full_cmd_line (bool, optional): The pattern is normally only matched against the process name.
-            When full_cmd_line is set to True, the full command line is used. Defaults to False.
+            if full_cmd_line is set to True, the full command line is used. Defaults to False.
 
     Returns:
-        list[int]: list of PID(s)
+        list of int: list of PID(s)
     """
     # default match predicate
     def default_predicate(target, given):
@@ -585,7 +582,7 @@ def kill_user_processes(user, sure_kill=False):
         sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        (list[psutil.Process] or None): list of process objects that remain alive if any. None otherwise.
+        list of psutil.Process or None): list of process objects that remain alive if any. None otherwise.
     """
     failed_processes = []
     for proc in get_user_processes(user):
@@ -607,10 +604,11 @@ def get_similar_processes(target_proc=None):
     """Gets similar processes to current process, started with same command line and same options.
 
     Args:
-        target_proc (int or psutil.Process, optional): pid, or psutil.Process object,\
-             if None then pid for current process will be used. Defaults to None.
-    Returns:
-        list[psutil.Process] -- list of similar process
+        target_proc (int or psutil.Process, optional): pid, or psutil.Process object.
+            if None then pid for current process will be used. Defaults to None.
+
+    Yields:
+        psutil.Process: psutil.Process object for all processes similar to a given process.
     """
     try:
         if target_proc is None:
@@ -663,6 +661,7 @@ def set_env_var(var_names, var_values):
     Args:
         var_names list[str]: A list of the names of all the environment variables to set
         varvalues list[str]: A list of all values for the environment variables
+
     Raises:
         j.exceptions.RuntimeError: if error happened during setting the environment variables
     """
@@ -699,9 +698,12 @@ def kill_process_by_name(process_name, sig=signal.SIGTERM, match_predicate=None,
         match_predicate (callable, optional): Function that does matching between\
             found processes and the targeted process, the function should accept\
             two arguments and return a boolean. Defaults to None.
+        timeout (int, optional): How long to wait for a process to terminate (seconds) before raise exception\
+            or, if sure_kill=True, send a SIGKILL. Defaults to 5.
+        sure_kill (bool, optional): Whether to fallback to SIGKILL if the timeout exceeded for the terminate operation or not. Defaults to False.
 
     Returns:
-        None or list[int] represents the IDs of the processes remaning alive.
+        None or list of int: represents the IDs of the processes remaning alive.
     """
     pids = get_pids(process_name, match_predicate=match_predicate)
     failed_processes = []
@@ -742,7 +744,6 @@ def is_port_listening(port, ipv6=False):
     Returns:
         bool: True if port is used, False otherwise.
     """
-    # XXX only support ipv4, also it apparently used to pick a free port, any way using nettools is preferred
     from jumpscale.sals import nettools
 
     ip6 = "::"
@@ -788,7 +789,7 @@ def get_defunct_processes():
     """Gets defunct (zombie) processes.
 
     Returns:
-        list[int]: List of processes ID(s).
+        list of int: List of processes ID(s).
     """
     zombie_pids = []
     for proc in psutil.process_iter():

--- a/jumpscale/sals/process/__init__.py
+++ b/jumpscale/sals/process/__init__.py
@@ -337,7 +337,6 @@ def get_filtered_pids(filterstr, excludes=None):
         )
         return pids
     except (psutil.AccessDenied, psutil.NoSuchProcess) as e:
-        j.logger.debug("logging and bypassing the exception occurred while iterating over the system processes")
         j.logger.exception("exception occurred while iterating over the system processes", exception=e)
         pass
 

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -1,4 +1,5 @@
 import string
+import os
 from math import ceil
 from random import randint
 from gevent import sleep
@@ -724,7 +725,7 @@ class ProcessTests(BaseTests):
         """
         self.info("Start a tail process from the currnet user.")
         user_pids = {}
-        current_user = j.sals.fs.expanduser("~").strip("/").strip("/home/")
+        current_user = os.path.basename(j.sals.fs.expanduser("~"))
         cmd = f"{TAIL_PROCESS_NAME} -f /dev/null"
         self.start_in_tmux(cmd)
 

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -763,9 +763,9 @@ class ProcessTests(BaseTests):
         users = sorted([current_user, user_1, user_2])
         sorted_pids = []
         for user in users:
-            if user == current_user and type_ == "sorted":
-                sorted_pids.extend(user_pids[user])
-            elif user == current_user and type_ == "regex":
+            # if user == current_user and type_ == "sorted":
+            #     sorted_pids.extend(user_pids[user])
+            if user == current_user and type_ == "regex":
                 sorted_pids.append(user_pids[user][0])
             else:
                 sorted_pids.append(user_pids[user])

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -39,12 +39,22 @@ class ProcessTests(BaseTests):
         sleep(1)
 
     def get_process_pids(self, process_name, full=False, user=None):
-        self.info(f"process name: {process_name}")
+        self.info(f"user name: {process_name}")
         options = []
         if full:
             options.append("-f")
         if user:
             options.append(f"-u {user}")
+        # D    uninterruptible sleep (usually IO)
+        # I    Idle kernel thread
+        # R    running or runnable (on run queue)
+        # S    interruptible sleep (waiting for an event to complete)
+        # T    stopped by job control signal
+        # t    stopped by debugger during the tracing
+        # W    paging (not valid since the 2.6.xx kernel)
+        # X    dead (should never be seen)
+        # Z    defunct ("zombie") process, terminated but not reaped by its parent
+        options.append("-r R, S")  # this required due to bug in pgrep exists before ubuntu 20
 
         cmd = f"pgrep {' '.join(options)} '{process_name}'"
         rc, output, error = j.sals.process.execute(cmd)

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -47,14 +47,14 @@ class ProcessTests(BaseTests):
             options.append(f"-u {user}")
         cmd = f"pgrep {' '.join(options)} '{process_name}'"
         rc, output, error = j.sals.process.execute(cmd)
-        self.info(f"ourput: {output}, error: {error}, rc: {rc}")
+        self.info(f"output: {output}, error: {error}, rc: {rc}")
         self.assertFalse(error)
         if not output:
             return []
         z_pids_str = " ".join(['"' + pid + '"' for pid in output.split()])  # excluding Dead processes
-        cmd = f"ps -o s= -o pid= {z_pids_str} | sed -n 's/^[^ZT][[:space:]]\+//p'"
+        cmd = f"ps -o s= -o pid= {z_pids_str} | sed -n 's/^[^ZT][[:space:]]\\+//p'"
         rc, output, error = j.sals.process.execute(cmd)
-        self.info(f"ourput: {output}, error: {error}, rc: {rc}")
+        self.info(f"output: {output}, error: {error}, rc: {rc}")
         self.assertFalse(error)
         self.info(f"output: {output}")
         pids = list(map(int, output.split()))

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -744,22 +744,11 @@ class ProcessTests(BaseTests):
         self.start_in_tmux(cmd)
 
         self.info("Get each user pids.")
-        cmd = f"pgrep -u {user_1} {TAIL_PROCESS_NAME}"
-        rc, output, error = j.sals.process.execute(cmd)
-        self.assertFalse(error)
-        self.assertTrue(output)
-        user_pids[user_1] = output.split()
+        user_pids[user_1] = self.get_process_pids(TAIL_PROCESS_NAME, user=user_1)
 
-        cmd = f"pgrep -u {user_2} {TAIL_PROCESS_NAME}"
-        rc, output, error = j.sals.process.execute(cmd)
-        self.assertFalse(error)
-        self.assertTrue(output)
-        user_pids[user_2] = output.split()
+        user_pids[user_2] = self.get_process_pids(TAIL_PROCESS_NAME, user=user_2)
 
-        pids = self.get_process_pids(TAIL_PROCESS_NAME)
-        pids.remove(user_pids[user_1])
-        pids.remove(user_pids[user_2])
-        user_pids[current_user] = pids
+        user_pids[current_user] = self.get_process_pids(TAIL_PROCESS_NAME, user=current_user)
 
         if type_ == "sorted":
             self.info("Get pids sorted with username.")

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -38,11 +38,13 @@ class ProcessTests(BaseTests):
         j.core.executors.tmux.execute_in_window(cmd, window_name, SESSION_NAME)
         sleep(1)
 
-    def get_process_pids(self, process_name, full=False, user=None):
+    def get_process_pids(self, process_name, full=False, user=None, exact=True):
         self.info(f"user name: {process_name}")
         options = []
         if full:
             options.append("-f")
+        if exact:
+            options.append("-x")
         if user:
             options.append(f"-u {user}")
         cmd = f"pgrep {' '.join(options)} '{process_name}'"

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -43,7 +43,7 @@ class ProcessTests(BaseTests):
         options = []
         if full:
             options.append("-f")
-        if exact:
+        if exact and not full:
             options.append("-x")
         if user:
             options.append(f"-u {user}")

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -42,6 +42,7 @@ class ProcessTests(BaseTests):
         rc, output, error = j.sals.process.execute(cmd)
         self.assertFalse(rc, error)
         pids = list(map(int, output.splitlines()))
+        self.info(f"output: {output}")
         return pids
 
     def create_user(self, username, file_path):

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -776,7 +776,7 @@ class ProcessTests(BaseTests):
             # if user == current_user and type_ == "regex":
             #     sorted_pids.append(user_pids[user][0])
             # else:
-            sorted_pids.append(user_pids[user])
+            sorted_pids.extend(user_pids[user])
         if type_ == "sorted":
             self.info("Check that the pids are sorted.")
             self.assertEqual(pids, sorted_pids)

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -501,8 +501,7 @@ class ProcessTests(BaseTests):
         self.assertTrue(j.sals.process.is_alive(pids[0]))
 
         self.info("Kill the process.")
-        killed = j.sals.process.kill(pids[0])
-        self.assertTrue(killed)
+        j.sals.process.kill(pids[0])
         sleep(1)
 
         self.info("Check that the process has been killed.")

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -23,7 +23,7 @@ class ProcessTests(BaseTests):
     def tearDown(self):
         j.core.executors.tmux.kill_session(SESSION_NAME)
         if self.get_process_pids(TAIL_PROCESS_NAME):
-            j.sals.process.kill_all(TAIL_PROCESS_NAME)
+            j.sals.process.kill_process_by_name(TAIL_PROCESS_NAME)
 
         for user in self.user_to_clear:
             cmd = f"""sudo userdel  {user};
@@ -508,7 +508,7 @@ class ProcessTests(BaseTests):
         pids = j.sals.process.get_pids(TAIL_PROCESS_NAME)
         self.assertFalse(pids)
 
-    @parameterized.expand(["kill_all", "kill_user_processes", "kill_process_by_name"])
+    @parameterized.expand(["kill_user_processes", "kill_process_by_name"])
     @pytest.mark.admin
     def test_16_get_kill_user_process(self, kill_method):
         """Test case for getting and killing user process/ killall processes.

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -242,7 +242,7 @@ class ProcessTests(BaseTests):
         """
         self.info("Start a process in tmux with check_start.")
         window_name = self.randstr()
-        start_cmd = f"tmux new-window -t {SESSION_NAME} -d -n {window_name} {TAIL_PROCESS_NAME} -f /dev/null"
+        start_cmd = f"tmux new-window -t {SESSION_NAME} -d -n {window_name} '{TAIL_PROCESS_NAME} -f /dev/null'"
         j.sals.process.check_start(cmd=start_cmd, filterstr=TAIL_PROCESS_NAME, n_instances=1)
 
         self.info("Check that the process has been started.")

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -364,7 +364,7 @@ class ProcessTests(BaseTests):
         self.assertAlmostEqual(memory_usage["used"], used, delta=1)
         self.assertAlmostEqual(memory_usage["percent"], percent, delta=5)
 
-    @pytest.mark.skip("https://github.com/threefoldtech/js-ng/issues/467")
+    #  @pytest.mark.skip("https://github.com/threefoldtech/js-ng/issues/467")
     def test_12_get_processes_info(self):
         """Test case for getting processes info.
 
@@ -388,7 +388,7 @@ class ProcessTests(BaseTests):
         self.assertEqual(len(pids), 1)
 
         self.info("Get processes info using SALS process.")
-        processes_info = j.sals.process.get_processes_info()
+        processes_info = j.sals.process.get_processes_info(limit=-1)
 
         self.info("Check that the python server is in the processes info.")
         found = False

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -38,10 +38,10 @@ class ProcessTests(BaseTests):
         sleep(1)
 
     def get_process_pids(self, process_name):
-        cmd = f"ps -aux | grep '{process_name}' | grep -v grep | awk '{{ print $2 }}'"
+        cmd = f"pidof {process_name}"
         rc, output, error = j.sals.process.execute(cmd)
         self.assertFalse(rc, error)
-        pids = list(map(int, output.splitlines()))
+        pids = list(map(int, output.split()))
         self.info(f"output: {output}")
         return pids
 
@@ -765,10 +765,10 @@ class ProcessTests(BaseTests):
         for user in users:
             # if user == current_user and type_ == "sorted":
             #     sorted_pids.extend(user_pids[user])
-            if user == current_user and type_ == "regex":
-                sorted_pids.append(user_pids[user][0])
-            else:
-                sorted_pids.append(user_pids[user])
+            # if user == current_user and type_ == "regex":
+            #     sorted_pids.append(user_pids[user][0])
+            # else:
+            sorted_pids.extend(user_pids[user])
         if type_ == "sorted":
             self.info("Check that the pids are sorted.")
             self.assertEqual(pids, sorted_pids)

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -450,10 +450,9 @@ class ProcessTests(BaseTests):
         self.assertEqual(process.name(), "python3")
 
         self.info("Kill the server by port.")
-        killed = j.sals.process.kill_process_by_port(port)
+        j.sals.process.kill_process_by_port(port)
 
         self.info("Check that the server pid is not exist.")
-        self.assertTrue(killed)
         pids = self.get_process_pids(PYTHON_SERVER_NAME, full=True)
         self.assertFalse(pids)
         self.assertFalse(j.sals.process.is_port_listening(port))

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -43,7 +43,7 @@ class ProcessTests(BaseTests):
         if full:
             options.append("-f")
         if user:
-            options.appens(f"-u {user}")
+            options.append(f"-u {user}")
 
         cmd = f"pgrep {' '.join(options)} '{process_name}'"
         rc, output, error = j.sals.process.execute(cmd)

--- a/tests/sals/process/test_process.py
+++ b/tests/sals/process/test_process.py
@@ -1,5 +1,5 @@
 import string
-import os
+import getpass
 from math import ceil
 from random import randint
 from gevent import sleep
@@ -731,7 +731,7 @@ class ProcessTests(BaseTests):
         """
         self.info("Start a tail process from the currnet user.")
         user_pids = {}
-        current_user = os.path.basename(j.sals.fs.expanduser("~"))
+        current_user = getpass.getuser()
         cmd = f"{TAIL_PROCESS_NAME} -f /dev/null"
         self.start_in_tmux(cmd)
 


### PR DESCRIPTION
### Description

sals.process cleanup/refactor

### Changes

- Fixing related issues and bugs #467, #557, #561.
- Refactoring and enhancing the module.
- Re-implementing some functions, removing the `ps` shell command completely, and depend on [psutil](https://psutil.readthedocs.io/en/latest/) instead.
- Many functions enriched with new args, and become more generic
- Ensuring complete docstring and matching [google style](https://google.github.io/styleguide/pyguide.html).
- Adding proper error handling.
- Adding proper logging.
- Remove redundant code, unused import, etc.
- Adding a new function kill_proc_tree() to kill all subprocesses that could have been spawn from a given process.
- Adding a new function kill_all_pids() to kill all processes in a given list of PIDs
- Adding more examples in the module docstring.
- improving the unit test, fixing few bugs.
- regenerate docs
 
### Related Issues

closes #467
#541
closes #557
closes #561

### Decisions Needed:

Suggested changes below are **not included in this PR** for compatibility reasons with any old code.
but it may be considered, discussed, and make decisions about:

- **1**: `kill()`, `check_start()` and `check_stop()` functions return `True` when succeded. raise an exception otherwise.

  https://github.com/threefoldtech/js-ng/blob/e610686d1536619076520f0dbd11c82a3b0cbe42/jumpscale/sals/process/__init__.py#L102
https://github.com/threefoldtech/js-ng/blob/e610686d1536619076520f0dbd11c82a3b0cbe42/jumpscale/sals/process/__init__.py#L271
https://github.com/threefoldtech/js-ng/blob/e610686d1536619076520f0dbd11c82a3b0cbe42/jumpscale/sals/process/__init__.py#L313

  * the returned `True` is redundant and not needed, it actually never return `False`. in case of the operation failed we raise an exception.

  **Decision:** the function should return None and the calling code should call the function inside try .. except, and never check for the output.

  **Update:** Solved, after discussion with @abom. now, these functions return None.

- **2**: `kill_all()` function default signal is `SIGKILL` and inconsistent with `kill()` function that have `SIGTERM` as a default signal also it almost have same functionality as `kill_process_by_name()` function.

  https://github.com/threefoldtech/js-ng/blob/e610686d1536619076520f0dbd11c82a3b0cbe42/jumpscale/sals/process/__init__.py#L167

  **Decision:** `kill_all()` default signal should be re-considered also the function itself should be deprecated and removed in favor of `kill_process_by_name()` because they are almost the same.

  **Update:** Solved, after discussion with @abom. now, this function deprecated and removed in favor of `kill_process_by_name()` 

- **3**: the module functions divided between functions that return the processes as a list[int] represents the processes ID(s) (due to it was initially parsing the PIDs from the `ps` shell command output), and functions that return the processes as psutil.Process objects. passing PIDs is not reliable in case the process is gone and its PID reused by another process, also this will affect the performance when we initiate the psutil.Process objects repeatedly from pids between function calls.

  * ex: we iterate through some psutil.Process objects in one function to do some work, when returning the function getting processes PIDs, appended it to a list, and send it to another function. the second function will again initiate a Process object to do its work. this affects the performance and may end with dealing with a different process than the intended one.
  
  **Decision:** as we now depend completely on psutil in this module, all functions should return psutil.Porcess objects instead of PIDs: list[int], another alternative, the affected functions - specially get_pids() - could take a parameter to decide whether it should return processes IDs or the Processes objects.

- **4**: `is_port_listening()` function is irrelevant in the process sal. it is already implemented in the nettools sal and should not re-implemented here.

  https://github.com/threefoldtech/js-ng/blob/e610686d1536619076520f0dbd11c82a3b0cbe42/jumpscale/sals/process/__init__.py#L578

  **Decision:**  the function should be deprecated and removed in favor of  `tcp_connection_test()` from the nettools sal.

### Checklist

- [X] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [X] Tests included
- [x] Build pass
- [X] Documentation
- [X] Code format and docstrings
