### PR TITLE
ETCD backend as config manager

### DIFF
--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -5,7 +5,7 @@ name: jsng-ci
 
 on:
   push:
-    branches: [ development ]
+    branches: [ development_reduce_etcd ]
   pull_request:
     branches: [ development ]
 
@@ -41,6 +41,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
           sudo pip3 install poetry
+          mkdir -p /tmp/etcd
+          curl -L https://storage.googleapis.com/etcd/v3.4.14/etcd-v3.4.14-linux-amd64.tar.gz -o /tmp/etcd-v3.4.14-linux-amd64.tar.gz
+          tar xzvf /tmp/etcd-v3.4.14-linux-amd64.tar.gz -C /tmp/etcd --strip-components=1
+          cp /tmp/etcd/etcd /usr/sbin/
+          cp /tmp/etcd/etcdctl /usr/sbin/
+          rm -f /tmp/etcd-v3.4.14-linux-amd64.tar.gz
+
       - name: Install
         run: |
           sudo poetry install -E all

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -5,7 +5,7 @@ name: jsng-ci
 
 on:
   push:
-    branches: [ development_reduce_etcd ]
+    branches: [ development ]
   pull_request:
     branches: [ development ]
 

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -44,8 +44,8 @@ jobs:
           mkdir -p /tmp/etcd
           curl -L https://storage.googleapis.com/etcd/v3.4.14/etcd-v3.4.14-linux-amd64.tar.gz -o /tmp/etcd-v3.4.14-linux-amd64.tar.gz
           tar xzvf /tmp/etcd-v3.4.14-linux-amd64.tar.gz -C /tmp/etcd --strip-components=1
-          cp /tmp/etcd/etcd /usr/sbin/
-          cp /tmp/etcd/etcdctl /usr/sbin/
+          sudo cp /tmp/etcd/etcd /usr/sbin/
+          sudo cp /tmp/etcd/etcdctl /usr/sbin/
           rm -f /tmp/etcd-v3.4.14-linux-amd64.tar.gz
 
       - name: Install

--- a/jumpscale/core/base/factory.py
+++ b/jumpscale/core/base/factory.py
@@ -59,6 +59,12 @@ try:
 except ImportError:
     pass
 
+try:
+    from .store.etcd import EtcdStore
+
+    STORES["etcd"] = EtcdStore
+except ImportError:
+    pass
 
 class DuplicateError(Exception):
     """

--- a/jumpscale/core/base/factory.py
+++ b/jumpscale/core/base/factory.py
@@ -51,7 +51,6 @@ try:
 except ImportError:
     pass
 
-
 try:
     from .store.mongo import MongoStore
 
@@ -65,6 +64,7 @@ try:
     STORES["etcd"] = EtcdStore
 except ImportError:
     pass
+
 
 class DuplicateError(Exception):
     """

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -1,5 +1,4 @@
 import etcd3
-import json
 
 from . import ConfigNotFound, EncryptedConfigStore, EncryptionMode
 
@@ -56,20 +55,7 @@ class EtcdStore(EncryptedConfigStore):
         if not self.etcd_client.get(key)[0]:
             raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
 
-        return json.loads(self.etcd_client.get(key)[0].decode())
-
-    def get(self, instance_name):
-        """
-        get instance config from etcd
-
-        Args:
-            instance_name (name): name
-
-        Returns:
-            instance: return config object
-        """
-        config = self.read(instance_name)
-        return self._process_config(config, EncryptionMode.Decrypt)
+        return self.etcd_client.get(key)[0]
 
     def write(self, instance_name, data):
         """

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -1,7 +1,40 @@
 import etcd3
+import json
 
 from . import ConfigNotFound, EncryptedConfigStore
 from .serializers import JsonSerializer
 
+
 class EtcdStore(EncryptedConfigStore):
-    pass
+    def __init__(self, location):
+        super().__init__(location, JsonSerializer())
+        etcd_config = self.config_env.get_store_config("etcd")
+        hostname = etcd_config.get("hostname", "localhost")
+        port = etcd_config.get("port", 2379)
+        self.etcd_client = etcd3.client(host=hostname, port=port)
+
+    def get_key(self, instance_name):
+        return ".".join([self.location.name, instance_name])
+
+    def read(self, instance_name):
+        key = self.get_key(instance_name)
+        if not self.etcd_client.get(instance_name):
+            raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
+
+        return self.etcd_client.get(key)[0].decode()
+
+    def write(self, instance_name, data):
+        key = self.get_key(instance_name)
+        self.etcd_client.put(key, data)
+        "folder1.folder2.instance_name"
+
+    def list_all(self):
+        return [item[1].key.decode().split(".")[-1] for item in self.etcd_client.get_all()]
+
+    # def find(self, cursor_=None, limit_=None, **query):
+    #     pass
+
+    def delete(self, instance_name):
+        key = self.get_key(instance_name)
+        return self.etcd_client.delete(key)
+

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -19,8 +19,8 @@ class EtcdStore(EncryptedConfigStore):
 
     def read(self, instance_name):
         key = self.get_key(instance_name)
-        if not self.etcd_client.get(instance_name)[0]:
-            raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
+        # if not self.etcd_client.get(instance_name)[0]:
+        #     raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
 
         return self.etcd_client.get(key)[0]
 

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -1,0 +1,7 @@
+import etcd3
+
+from . import ConfigNotFound, EncryptedConfigStore
+from .serializers import JsonSerializer
+
+class EtcdStore(EncryptedConfigStore):
+    pass

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -44,13 +44,13 @@ class EtcdStore(EncryptedConfigStore):
 
     def read(self, instance_name):
         """
-        read instance config from mongo
+        read instance config from etcd
 
         Args:
             instance_name (name): name
 
         Returns:
-            str: data
+            str: return json object
         """
         key = self.get_key(instance_name)
         if not self.etcd_client.get(key)[0]:
@@ -59,6 +59,15 @@ class EtcdStore(EncryptedConfigStore):
         return json.loads(self.etcd_client.get(key)[0].decode())
 
     def get(self, instance_name):
+        """
+        get instance config from etcd
+
+        Args:
+            instance_name (name): name
+
+        Returns:
+            instance: return config object
+        """
         config = self.read(instance_name)
         return self._process_config(config, EncryptionMode.Decrypt)
 

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -7,7 +7,21 @@ from .serializers import JsonSerializer
 
 
 class EtcdStore(EncryptedConfigStore):
+    """
+    EtcdStore store is an EncryptedConfigStore
+
+    It saves the data in etcd and configuration for etcd comes from `config_env.get_store_config("etcd")`
+    """
+
     def __init__(self, location):
+        """
+        create a new etcd store, the location given will be used to generate keys
+
+        this keys will be combined to get/set instance config
+
+        Args:
+            location (Location)
+        """
         super().__init__(location, JsonSerializer())
         etcd_config = self.config_env.get_store_config("etcd")
         hostname = etcd_config.get("hostname", "localhost")
@@ -15,9 +29,29 @@ class EtcdStore(EncryptedConfigStore):
         self.etcd_client = etcd3.client(host=hostname, port=port)
 
     def get_key(self, instance_name):
+        """
+        get a key for an instance
+
+        this will return a dot-separated key derived from current location
+
+        Args:
+            instance_name (str): name
+
+        Returns:
+            str: key
+        """
         return ".".join([self.location.name, instance_name])
 
     def read(self, instance_name):
+        """
+        read instance config from mongo
+
+        Args:
+            instance_name (name): name
+
+        Returns:
+            str: data
+        """
         key = self.get_key(instance_name)
         # if not self.etcd_client.get(instance_name)[0]:
         #     raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
@@ -29,14 +63,37 @@ class EtcdStore(EncryptedConfigStore):
         return self._process_config(config, EncryptionMode.Decrypt)
 
     def write(self, instance_name, data):
+        """
+        set data with the corresponding key for this instance
+
+        Args:
+            instance_name (str): name
+            data (str): data
+
+        Returns:
+            bool: written or not
+        """
         key = self.get_key(instance_name)
         self.etcd_client.put(key, data)
-        "folder1.folder2.instance_name"
 
     def list_all(self):
+        """
+        get all names of instances (instance keys)
+
+        Returns:
+            List[str]: list of instance names
+        """
         return [item[1].key.decode().split(".")[-1] for item in self.etcd_client.get_all()]
 
     def delete(self, instance_name):
+        """
+        delete given instance
+
+        Args:
+            instance_name (str): name
+
+        Returns:
+            bool
+        """
         key = self.get_key(instance_name)
         return self.etcd_client.delete(key)
-

--- a/jumpscale/core/base/store/etcd.py
+++ b/jumpscale/core/base/store/etcd.py
@@ -53,10 +53,10 @@ class EtcdStore(EncryptedConfigStore):
             str: data
         """
         key = self.get_key(instance_name)
-        # if not self.etcd_client.get(instance_name)[0]:
-        #     raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
+        if not self.etcd_client.get(key)[0]:
+            raise ConfigNotFound(f"cannot find config for {instance_name} at {key}")
 
-        return self.etcd_client.get(key)[0]
+        return json.loads(self.etcd_client.get(key)[0].decode())
 
     def get(self, instance_name):
         config = self.read(instance_name)

--- a/jumpscale/core/config/config.py
+++ b/jumpscale/core/config/config.py
@@ -135,7 +135,7 @@ def get_default_config():
         "stores": {
             "redis": {"hostname": "localhost", "port": 6379},
             "mongo": {"hostname": "localhost", "port": 27017},
-            "etcd": {"hostname": "localhost","port":2379},
+            "etcd": {"hostname": "localhost", "port": 2379},
             "filesystem": {"path": os.path.expanduser(os.path.join(config_root, "secureconfig"))},
             "whoosh": {"path": os.path.expanduser(os.path.join(config_root, "whoosh_indexes"))},
         },

--- a/jumpscale/core/config/config.py
+++ b/jumpscale/core/config/config.py
@@ -135,6 +135,7 @@ def get_default_config():
         "stores": {
             "redis": {"hostname": "localhost", "port": 6379},
             "mongo": {"hostname": "localhost", "port": 27017},
+            "etcd": {"hostname": "localhost","port":2379},
             "filesystem": {"path": os.path.expanduser(os.path.join(config_root, "secureconfig"))},
             "whoosh": {"path": os.path.expanduser(os.path.join(config_root, "whoosh_indexes"))},
         },

--- a/poetry.lock
+++ b/poetry.lock
@@ -1148,7 +1148,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 all = ["dill", "Whoosh", "pymongo", "faker", "terminaltables", "watchdog", "GitPython", "docker", "etcd3"]
 dill = ["dill"]
 docker = ["docker"]
-etcd3 = ["etcd3"]
+etcd = ["etcd3"]
 fake = ["faker"]
 git = ["GitPython"]
 mongo = ["pymongo"]
@@ -1159,7 +1159,7 @@ whoosh = ["Whoosh"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "4d4864e00aa35767d9ea2be8d03337e766a5edde98606391507851d692bddc75"
+content-hash = "7bbad87590bf12815ecf3ca602e402139411ec9e3e660c65354707e51db380d4"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -254,6 +254,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "etcd3"
+version = "0.12.0"
+description = "Python client for the etcd3 API"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+grpcio = ">=1.27.1"
+protobuf = ">=3.6.1"
+six = ">=1.12.0"
+tenacity = ">=6.1.0"
+
+[[package]]
 name = "fabric"
 version = "2.5.0"
 description = "High level SSH command execution"
@@ -356,6 +370,20 @@ description = "Lightweight in-process concurrent programming"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "grpcio"
+version = "1.35.0"
+description = "HTTP/2-based RPC framework"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.5.2"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.35.0)"]
 
 [[package]]
 name = "hypothesis"
@@ -704,6 +732,17 @@ six = ">=1.9.0"
 wcwidth = "*"
 
 [[package]]
+name = "protobuf"
+version = "3.14.0"
+description = "Protocol Buffers"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.9"
+
+[[package]]
 name = "psutil"
 version = "5.8.0"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -960,6 +999,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "tenacity"
+version = "6.3.1"
+description = "Retry code until it succeeds"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "terminaltables"
 version = "3.1.0"
 description = "Generate simple tables in terminals from a nested list of strings."
@@ -1092,9 +1145,10 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-all = ["dill", "Whoosh", "pymongo", "faker", "terminaltables", "watchdog", "GitPython", "docker"]
+all = ["dill", "Whoosh", "pymongo", "faker", "terminaltables", "watchdog", "GitPython", "docker", "etcd3"]
 dill = ["dill"]
 docker = ["docker"]
+etcd3 = ["etcd3"]
 fake = ["faker"]
 git = ["GitPython"]
 mongo = ["pymongo"]
@@ -1105,7 +1159,7 @@ whoosh = ["Whoosh"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "bb1802fbffb4a6402331956e6f61a047c0fede888f726db866a67939d229d692"
+content-hash = "4d4864e00aa35767d9ea2be8d03337e766a5edde98606391507851d692bddc75"
 
 [metadata.files]
 appdirs = [
@@ -1195,6 +1249,7 @@ cffi = [
     {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
     {file = "cffi-1.14.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd"},
     {file = "cffi-1.14.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:7ef7d4ced6b325e92eb4d3502946c78c5367bc416398d387b39591532536734e"},
     {file = "cffi-1.14.4-cp39-cp39-win32.whl", hash = "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3"},
     {file = "cffi-1.14.4-cp39-cp39-win_amd64.whl", hash = "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b"},
     {file = "cffi-1.14.4.tar.gz", hash = "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"},
@@ -1302,6 +1357,9 @@ docker = [
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
+etcd3 = [
+    {file = "etcd3-0.12.0.tar.gz", hash = "sha256:89a704cb389bf0a010a1fa050ce19342d23bf6371ebda1c21cfe8ff3ed488726"},
+]
 fabric = [
     {file = "fabric-2.5.0-py2.py3-none-any.whl", hash = "sha256:160331934ea60036604928e792fa8e9f813266b098ef5562aa82b88527740389"},
     {file = "fabric-2.5.0.tar.gz", hash = "sha256:24842d7d51556adcabd885ac3cf5e1df73fc622a1708bf3667bf5927576cdfa6"},
@@ -1369,6 +1427,54 @@ greenlet = [
     {file = "greenlet-0.4.16-cp38-cp38-win32.whl", hash = "sha256:e695ac8c3efe124d998230b219eb51afb6ef10524a50b3c45109c4b77a8a3a92"},
     {file = "greenlet-0.4.16-cp38-cp38-win_amd64.whl", hash = "sha256:133ba06bad4e5f2f8bf6a0ac434e0fd686df749a86b3478903b92ec3a9c0c90b"},
     {file = "greenlet-0.4.16.tar.gz", hash = "sha256:6e06eac722676797e8fce4adb8ad3dc57a1bb3adfb0dd3fdf8306c055a38456c"},
+]
+grpcio = [
+    {file = "grpcio-1.35.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:95cc4d2067deced18dc807442cf8062a93389a86abf8d40741120054389d3f29"},
+    {file = "grpcio-1.35.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:d186a0ce291f4386e28a7042ec31c85250b0c2e25d2794b87fa3c15ff473c46c"},
+    {file = "grpcio-1.35.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:c8d0a6a58a42275c6cb616e7cb9f9fcf5eba1e809996546e561cd818b8f7cff7"},
+    {file = "grpcio-1.35.0-cp27-cp27m-win32.whl", hash = "sha256:8d08f90d72a8e8d9af087476337da76d26749617b0a092caff4e684ce267af21"},
+    {file = "grpcio-1.35.0-cp27-cp27m-win_amd64.whl", hash = "sha256:0072ec4563ab4268c4c32e936955085c2d41ea175b662363496daedd2273372c"},
+    {file = "grpcio-1.35.0-cp27-cp27mu-linux_armv7l.whl", hash = "sha256:aca45d2ccb693c9227fbf21144891422a42dc4b76b52af8dd1d4e43afebe321d"},
+    {file = "grpcio-1.35.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:87147b1b306c88fe7dca7e3dff8aefd1e63d6aed86e224f9374ddf283f17d7f1"},
+    {file = "grpcio-1.35.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:22edfc278070d54f3ab7f741904e09155a272fe934e842babbf84476868a50de"},
+    {file = "grpcio-1.35.0-cp35-cp35m-linux_armv7l.whl", hash = "sha256:f3654a52f72ba28953dbe2e93208099f4903f4b3c07dc7ff4db671c92968111d"},
+    {file = "grpcio-1.35.0-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:dc2589370ef84eb1cc53530070d658a7011d2ee65f18806581809c11cd016136"},
+    {file = "grpcio-1.35.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:f0c27fd16582a303e5baf6cffd9345c9ac5f855d69a51232664a0b888a77ba80"},
+    {file = "grpcio-1.35.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:b2985f73611b637271b00d9c4f177e65cc3193269bc9760f16262b1a12757265"},
+    {file = "grpcio-1.35.0-cp35-cp35m-manylinux2014_i686.whl", hash = "sha256:acb489b7aafdcf960f1a0000a1f22b45e5b6ccdf8dba48f97617d627f4133195"},
+    {file = "grpcio-1.35.0-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:16fd33030944672e49e0530dec2c60cd4089659ccdf327e99569b3b29246a0b6"},
+    {file = "grpcio-1.35.0-cp35-cp35m-win32.whl", hash = "sha256:1757e81c09132851e85495b802fe4d4fbef3547e77fa422a62fb4f7d51785be0"},
+    {file = "grpcio-1.35.0-cp35-cp35m-win_amd64.whl", hash = "sha256:35b72884e09cbc46c564091f4545a39fa66d132c5676d1a6e827517fff47f2c1"},
+    {file = "grpcio-1.35.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:17940a7dc461066f28816df48be44f24d3b9f150db344308ee2aeae033e1af0b"},
+    {file = "grpcio-1.35.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:75ea903edc42a8c6ec61dbc5f453febd79d8bdec0e1bad6df7088c34282e8c42"},
+    {file = "grpcio-1.35.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b180a3ec4a5d6f96d3840c83e5f8ab49afac9fa942921e361b451d7a024efb00"},
+    {file = "grpcio-1.35.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e163c27d2062cd3eb07057f23f8d1330925beaba16802312b51b4bad33d74098"},
+    {file = "grpcio-1.35.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:764b50ba1a15a2074cdd1a841238f2dead0a06529c495a46821fae84cb9c7342"},
+    {file = "grpcio-1.35.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:088c8bea0f6b596937fefacf2c8df97712e7a3dd49496975049cc95dbf02af1a"},
+    {file = "grpcio-1.35.0-cp36-cp36m-win32.whl", hash = "sha256:1aa53f82362c7f2791fe0cdd9a3b3aec325c11d8f0dfde600f91907dfaa8546b"},
+    {file = "grpcio-1.35.0-cp36-cp36m-win_amd64.whl", hash = "sha256:efb3d67405eb8030db6f27920b4be023fabfb5d4e09c34deab094a7c473a5472"},
+    {file = "grpcio-1.35.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:44aaa6148d18a8e836f99dadcdec17b27bc7ec0995b2cc12c94e61826040ec90"},
+    {file = "grpcio-1.35.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:18ad7644e23757420ea839ac476ef861e4f4841c8566269b7c91c100ca1943b3"},
+    {file = "grpcio-1.35.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:859a0ceb23d7189362cc06fe7e906e9ed5c7a8f3ac960cc04ce13fe5847d0b62"},
+    {file = "grpcio-1.35.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3e7d4428ed752fdfe2dddf2a404c93d3a2f62bf4b9109c0c10a850c698948891"},
+    {file = "grpcio-1.35.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:a36151c335280b09afd5123f3b25085027ae2b10682087a4342fb6f635b928fb"},
+    {file = "grpcio-1.35.0-cp37-cp37m-win32.whl", hash = "sha256:dfecb2acd3acb8bb50e9aa31472c6e57171d97c1098ee67cd283a6fe7d56a926"},
+    {file = "grpcio-1.35.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e87e55fba98ebd7b4c614dcef9940dc2a7e057ad8bba5f91554934d47319a35b"},
+    {file = "grpcio-1.35.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:da44bf613eed5d9e8df0785463e502a416de1be6e4ac31edbe99c9111abaed5f"},
+    {file = "grpcio-1.35.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:9e503eaf853199804a954dc628c5207e67d6c7848dcba42a997fbe718618a2b1"},
+    {file = "grpcio-1.35.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:6ba3d7acf70acde9ce27e22921db921b84a71be578b32739536c32377b65041a"},
+    {file = "grpcio-1.35.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:048c01d1eb5c2ae7cba2254b98938d2fc81f6dc10d172d9261d65266adb0fdb3"},
+    {file = "grpcio-1.35.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:efd896e8ca7adb2654cf014479a5e1f74e4f776b6b2c0fbf95a6c92787a6631a"},
+    {file = "grpcio-1.35.0-cp38-cp38-win32.whl", hash = "sha256:8a29a26b9f39701ce15aa1d5aa5e96e0b5f7028efe94f95341a4ed8dbe4bed78"},
+    {file = "grpcio-1.35.0-cp38-cp38-win_amd64.whl", hash = "sha256:aea3d592a7ece84739b92d212cd16037c51d84a259414f64b51c14e946611f3d"},
+    {file = "grpcio-1.35.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:2f8e8d35d4799aa1627a212dbe8546594abf4064056415c31bd1b3b8f2a62027"},
+    {file = "grpcio-1.35.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:9f0da13b215068e7434b161a35d0b4e92140ffcfa33ddda9c458199ea1d7ce45"},
+    {file = "grpcio-1.35.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:7ae408780b79c9b9b91a2592abd1d7abecd05675d988ea75038580f420966b59"},
+    {file = "grpcio-1.35.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:0f714e261e1d63615476cda4ee808a79cca62f8f09e2943c136c2f87ec5347b1"},
+    {file = "grpcio-1.35.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:7ee7d54da9d176d3c9a0f47c04d7ff6fdc6ee1c17643caff8c33d6c8a70678a4"},
+    {file = "grpcio-1.35.0-cp39-cp39-win32.whl", hash = "sha256:94c3b81089a86d3c5877d22b07ebc66b5ed1d84771e24b001844e29a5b6178dd"},
+    {file = "grpcio-1.35.0-cp39-cp39-win_amd64.whl", hash = "sha256:399ee377b312ac652b07ef4365bbbba009da361fa7708c4d3d4ce383a1534ea7"},
+    {file = "grpcio-1.35.0.tar.gz", hash = "sha256:7bd0ebbb14dde78bf66a1162efd29d3393e4e943952e2f339757aa48a184645c"},
 ]
 hypothesis = [
     {file = "hypothesis-4.57.1-py3-none-any.whl", hash = "sha256:94f0910bc87e0ae8c098f4ada28dfdc381245e0c8079c674292b417dbde144b5"},
@@ -1530,6 +1636,26 @@ prompt-toolkit = [
     {file = "prompt_toolkit-2.0.10-py2-none-any.whl", hash = "sha256:e7f8af9e3d70f514373bf41aa51bc33af12a6db3f71461ea47fea985defb2c31"},
     {file = "prompt_toolkit-2.0.10-py3-none-any.whl", hash = "sha256:46642344ce457641f28fc9d1c9ca939b63dadf8df128b86f1b9860e59c73a5e4"},
     {file = "prompt_toolkit-2.0.10.tar.gz", hash = "sha256:f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db"},
+]
+protobuf = [
+    {file = "protobuf-3.14.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:629b03fd3caae7f815b0c66b41273f6b1900a579e2ccb41ef4493a4f5fb84f3a"},
+    {file = "protobuf-3.14.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:5b7a637212cc9b2bcf85dd828b1178d19efdf74dbfe1ddf8cd1b8e01fdaaa7f5"},
+    {file = "protobuf-3.14.0-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:43b554b9e73a07ba84ed6cf25db0ff88b1e06be610b37656e292e3cbb5437472"},
+    {file = "protobuf-3.14.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:5e9806a43232a1fa0c9cf5da8dc06f6910d53e4390be1fa06f06454d888a9142"},
+    {file = "protobuf-3.14.0-cp35-cp35m-win32.whl", hash = "sha256:1c51fda1bbc9634246e7be6016d860be01747354ed7015ebe38acf4452f470d2"},
+    {file = "protobuf-3.14.0-cp35-cp35m-win_amd64.whl", hash = "sha256:4b74301b30513b1a7494d3055d95c714b560fbb630d8fb9956b6f27992c9f980"},
+    {file = "protobuf-3.14.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:86a75477addde4918e9a1904e5c6af8d7b691f2a3f65587d73b16100fbe4c3b2"},
+    {file = "protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ecc33531a213eee22ad60e0e2aaea6c8ba0021f0cce35dbf0ab03dee6e2a23a1"},
+    {file = "protobuf-3.14.0-cp36-cp36m-win32.whl", hash = "sha256:72230ed56f026dd664c21d73c5db73ebba50d924d7ba6b7c0d81a121e390406e"},
+    {file = "protobuf-3.14.0-cp36-cp36m-win_amd64.whl", hash = "sha256:0fc96785262042e4863b3f3b5c429d4636f10d90061e1840fce1baaf59b1a836"},
+    {file = "protobuf-3.14.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4e75105c9dfe13719b7293f75bd53033108f4ba03d44e71db0ec2a0e8401eafd"},
+    {file = "protobuf-3.14.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2a7e2fe101a7ace75e9327b9c946d247749e564a267b0515cf41dfe450b69bac"},
+    {file = "protobuf-3.14.0-cp37-cp37m-win32.whl", hash = "sha256:b0d5d35faeb07e22a1ddf8dce620860c8fe145426c02d1a0ae2688c6e8ede36d"},
+    {file = "protobuf-3.14.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8971c421dbd7aad930c9bd2694122f332350b6ccb5202a8b7b06f3f1a5c41ed5"},
+    {file = "protobuf-3.14.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9616f0b65a30851e62f1713336c931fcd32c057202b7ff2cfbfca0fc7d5e3043"},
+    {file = "protobuf-3.14.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:22bcd2e284b3b1d969c12e84dc9b9a71701ec82d8ce975fdda19712e1cfd4e00"},
+    {file = "protobuf-3.14.0-py2.py3-none-any.whl", hash = "sha256:0e247612fadda953047f53301a7b0407cb0c3cb4ae25a6fde661597a04039b3c"},
+    {file = "protobuf-3.14.0.tar.gz", hash = "sha256:1d63eb389347293d8915fb47bee0951c7b5dab522a4a60118b9a18f33e21f8ce"},
 ]
 psutil = [
     {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
@@ -1747,6 +1873,10 @@ smmap = [
 sortedcontainers = [
     {file = "sortedcontainers-2.3.0-py2.py3-none-any.whl", hash = "sha256:37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f"},
     {file = "sortedcontainers-2.3.0.tar.gz", hash = "sha256:59cc937650cf60d677c16775597c89a960658a09cf7c1a668f86e1e4464b10a1"},
+]
+tenacity = [
+    {file = "tenacity-6.3.1-py2.py3-none-any.whl", hash = "sha256:baed357d9f35ec64264d8a4bbf004c35058fad8795c5b0d8a7dc77ecdcbb8f39"},
+    {file = "tenacity-6.3.1.tar.gz", hash = "sha256:e14d191fb0a309b563904bbc336582efe2037de437e543b38da749769b544d7f"},
 ]
 terminaltables = [
     {file = "terminaltables-3.1.0.tar.gz", hash = "sha256:f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pymongo = { version = "^3.11.2", optional = true }
 dill = ["dill"]
 whoosh = ["Whoosh"]
 mongo = ["pymongo"]
+etcd3 = ["etcd3"]
 # optional modules, mostly define __optional__ = True before export_module_as
 fake = ["faker"]
 terminaltable = ["terminaltables"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ watchdog = { version = "^0.9.0", optional = true }
 GitPython = { version = "^3.0", optional = true }
 docker = { version = "^4.2.0", optional = true }
 pymongo = { version = "^3.11.2", optional = true }
+etcd3 = { version = "^0.12.0", optional = true }
 
 [tool.poetry.extras]
 # core extras
@@ -54,7 +55,7 @@ terminaltable = ["terminaltables"]
 syncer = ["watchdog"]
 git = ["GitPython"]
 docker = ["docker"]
-all = ["dill", "Whoosh", "pymongo", "faker", "terminaltables", "watchdog", "GitPython", "docker"]
+all = ["dill", "Whoosh", "pymongo", "faker", "terminaltables", "watchdog", "GitPython", "docker","etcd3"]
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ etcd3 = { version = "^0.12.0", optional = true }
 dill = ["dill"]
 whoosh = ["Whoosh"]
 mongo = ["pymongo"]
-etcd3 = ["etcd3"]
+etcd = ["etcd3"]
 # optional modules, mostly define __optional__ = True before export_module_as
 fake = ["faker"]
 terminaltable = ["terminaltables"]

--- a/tests/core/base/test_store_mongo.py
+++ b/tests/core/base/test_store_mongo.py
@@ -99,7 +99,7 @@ class MongoStoreTests(BaseTests):
         **Test Scenario**
 
         - Create three instances.
-        - Check that the instance are stored in redis.
+        - Check that the instance are stored in mongo.
         - List all instances and check that three instance found.
         """
         self.info("Create three instances.")


### PR DESCRIPTION
### Description

Add etcd backend as a config manager

### Changes

- Add optional etcd3 python package
- Add etcd3 backend as config manager
- Add etcd3 in tests for stored factories

### Related Issues

#544 

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
