### PR TITLE
fixing issue#572

### DIFF
--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y python${{ matrix.python-version }} git tmux redis net-tools
+          sudo apt-get install -y python${{ matrix.python-version }}
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
+          sudo apt-get install -y python3-setuptools python3-pip git tmux redis net-tools
           sudo which python3
-          sudo python3 -m pip install --upgrade pip
-          sudo python3 -m pip install setuptools poetry
+          sudo python3 -m pip install poetry
       - name: Install
         run: |
           sudo poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -46,7 +46,7 @@ jobs:
           poetry install
       - name: Generate coverage report and run tests
         run: |
-          poetry run sudo python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          poetry run sudo $pythonLocation/python -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y python${{ matrix.python-version }} git python3-setuptools tmux redis net-tools
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
           sudo which python3
           sudo python3 -m pip install poetry
       - name: Install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y python${{ matrix.python-version }} git python3-setuptools tmux redis net-tools
+          sudo apt-get install -y python${{ matrix.python-version }} git tmux redis net-tools
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
           sudo which python3
-          sudo python3 -m pip install poetry
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install setuptools poetry
       - name: Install
         run: |
           sudo poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,14 +39,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          python -m pip install --upgrade pip
-          python -m pip install poetry
+          sudo $pythonLocation -m pip install --upgrade pip
+          sudo $pythonLocation -m pip install poetry
       - name: Install
         run: |
           poetry install
       - name: Generate coverage report and run tests
         run: |
-          poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -42,7 +42,7 @@ jobs:
           python -m pip install poetry
       - name: Install
         run: |
-          poerty config virtualenvs.in-project true
+          poetry config virtualenvs.in-project true
           poetry install
       - name: Set python version for poetry
         run: |

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -41,7 +41,6 @@ jobs:
           sudo apt-get install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-dev
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
           sudo apt-get install -y git python3-pip python3-venv python3-setuptools tmux redis net-tools
-          sudo which python3
           sudo python3 -m pip install poetry
       - name: Install
         run: |

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -38,15 +38,15 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          python -m pip install --upgrade pip
-          python -m pip install poetry
+          sudo apt-get install -y python${{ matrix.python-version }} git python3-setuptools tmux redis net-tools
+          sudo which python3
+          sudo python3 -m pip install poetry
       - name: Install
         run: |
-          poetry install
+          sudo poetry install
       - name: Generate coverage report and run tests
         run: |
-          poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          sudo pip3 install poetry
+          sudo python -m pip install poetry
       - name: Install
         run: |
           sudo poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -40,8 +40,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python${{ matrix.python-version }}
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
-          sudo apt-get install -y python3-setuptools python3-pip git tmux redis net-tools
+          sudo apt-get install -y git tmux redis net-tools
           sudo which python3
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install setuptools -U
           sudo python3 -m pip install poetry
       - name: Install
         run: |

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -25,10 +25,10 @@ jobs:
             python-version: 3.8
             experimental: true
             name: Experimental build - latest Ubuntu
-          - python-version: 3.9
-            os: ubuntu-18.04
-            experimental: true
-            name: Experimental build - latest Python
+          #- python-version: 3.9
+          #  os: ubuntu-18.04
+          #  experimental: true
+          #  name: Experimental build - latest Python
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -39,6 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
+          python -m pip install --upgrade pip
           python -m pip install poetry
       - name: Install
         run: |

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,10 +39,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | sudo python3 -
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
       - name: Install
         run: |
-          sudo $HOME/.poetry/bin/poetry install
+          $HOME/.poetry/bin/poetry install
       - name: Generate coverage report and run tests
         run: |
           sudo $HOME/.poetry/bin/poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,13 +39,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          python -m pip --upgrade pip
+          python -m pip install poetry
       - name: Install
         run: |
-          sudo poetry install
+          poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -40,10 +40,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-dev
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
-          sudo apt-get install -y python3-setuptools git tmux redis net-tools
+          sudo apt-get install -y git python3-pip python3-venv python3-setuptools tmux redis net-tools
           sudo which python3
-          sudo python3 -m pip install --upgrade pip
-          sudo python3 -m pip install wheel poetry
+          sudo python3 -m pip install poetry
       - name: Install
         run: |
           sudo poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -47,8 +47,8 @@ jobs:
           PYTHON=$(which python)
           echo $PYTHON
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
-          sudo $POETRY install
-          sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo -H $POETRY install
+          sudo -H $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           poetry install
       - name: Set python version for poetry
+        run: |
           POETRY=$(which poetry)
           echo $POETRY
           PYTHON=$(which python)

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -47,8 +47,9 @@ jobs:
           PYTHON=$(which python)
           echo $PYTHON
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
-          sudo -H $POETRY install
-          sudo -H $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          $POETRY config virtualenvs.in-project true
+          $POETRY install
+          sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -42,10 +42,10 @@ jobs:
           python -m pip install poetry
       - name: Install
         run: |
-          sudo poetry install
+          poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,14 +39,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | sudo python3 -
       - name: Install
         run: |
-          $HOME/.poetry/bin/poetry install
+          sudo poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo $HOME/.poetry/bin/poetry env use /home/runner/.cache/pypoetry/virtualenvs/*-py${{ matrix.python-version }}
-          sudo $HOME/.poetry/bin/poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -37,12 +37,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Gathering deps
         run: |
-          sudo su
           sudo apt-get update
-          alias python3=$pythonLocation
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          python3 -m pip install --upgrade pip
-          python3 -m pip install poetry
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | sudo python3 -
       - name: Install
         run: |
           sudo poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -17,14 +17,9 @@ jobs:
       fail-fast: false
       # max-parallel: 9
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8]
         experimental: [false]
-        include:
-          - os: ubuntu-20.04
-            python-version: 3.8
-            experimental: true
-            name: Experimental build - latest Ubuntu
           #- python-version: 3.9
           #  os: ubuntu-18.04
           #  experimental: true
@@ -39,13 +34,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | sudo python3 -
+          sudo pip3 install poetry
       - name: Install
         run: |
           sudo poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -40,9 +40,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
           python -m pip install poetry
-      - name: Install
-        run: |
-          poetry install
       - name: Generate coverage report and run tests
         run: |
           POETRY=$(which poetry)
@@ -50,6 +47,7 @@ jobs:
           PYTHON=$(which python)
           echo $PYTHON
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
+          sudo $POETRY install
           sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y python${{ matrix.python-version }}
+          sudo apt-get install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-dev
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
           sudo apt-get install -y python3-setuptools git tmux redis net-tools
           sudo which python3

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          python -m pip --upgrade pip
+          python -m pip install --upgrade pip
           python -m pip install poetry
       - name: Install
         run: |

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Generate coverage report and run tests
         run: |
           POETRY=$(which poetry)
-          echo $POETRY
           sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -44,20 +44,14 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry install
-      - name: Set python version for poetry
+      - name: Set default python version for root
         run: |
-          POETRY=$(which poetry)
-          echo $POETRY
           PYTHON=$(which python)
-          echo $PYTHON
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
       - name: Generate coverage report and run tests
         run: |
           POETRY=$(which poetry)
           echo $POETRY
-          PYTHON=$(which python)
-          echo $PYTHON
-          sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
           sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -44,10 +44,6 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry install
-      - name: Set default python version for root
-        run: |
-          PYTHON=$(which python)
-          sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
       - name: Generate coverage report and run tests
         run: |
           POETRY=$(which poetry)

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -37,16 +37,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Gathering deps
         run: |
+          sudo su
           sudo apt-get update
+          alias python3=$pythonLocation
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          python -m pip install --upgrade pip
-          python -m pip install poetry
+          python3 -m pip install --upgrade pip
+          python3 -m pip install poetry
       - name: Install
         run: |
-          poetry install
+          sudo poetry install
       - name: Generate coverage report and run tests
         run: |
-          poetry run sudo $pythonLocation/python -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -38,16 +38,20 @@ jobs:
       - name: Gathering deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-dev
-          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
-          sudo apt-get install -y git python3-pip python3-venv python3-setuptools tmux redis net-tools
-          sudo python3 -m pip install poetry
+          sudo apt-get install -y git python3-setuptools tmux redis net-tools
+          python -m pip install poetry
       - name: Install
         run: |
-          sudo poetry install
+          poetry install
+      - name: Set python version for poetry
+          POETRY=$(which poetry)
+          echo $POETRY
+          PYTHON=$(which python)
+          echo $PYTHON
+          sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
       - name: Generate coverage report and run tests
         run: |
-          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -40,15 +40,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
           python -m pip install poetry
-      - name: Generate coverage report and run tests
+      - name: Install
+        run: |
+          poerty config virtualenvs.in-project true
+          poetry install
+      - name: Set python version for poetry
         run: |
           POETRY=$(which poetry)
           echo $POETRY
           PYTHON=$(which python)
           echo $PYTHON
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
-          $POETRY config virtualenvs.in-project true
-          $POETRY install
+      - name: Generate coverage report and run tests
+        run: |
           sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -42,10 +42,10 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | sudo python3 -
       - name: Install
         run: |
-          sudo poetry install
+          sudo $HOME/.poetry/bin/poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo $HOME/.poetry/bin/poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,14 +39,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          sudo $pythonLocation/python -m pip install --upgrade pip
-          sudo $pythonLocation/python -m pip install poetry
+          python -m pip install --upgrade pip
+          python -m pip install poetry
       - name: Install
         run: |
           poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          poetry run sudo python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,14 +39,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          python -m pip install --upgrade pip
-          python -m pip install poetry
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
       - name: Install
         run: |
-          poetry install
+          sudo poetry install
       - name: Generate coverage report and run tests
         run: |
-          poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -43,15 +43,13 @@ jobs:
       - name: Install
         run: |
           poetry install
-      - name: Set python version for poetry
+      - name: Generate coverage report and run tests
         run: |
           POETRY=$(which poetry)
           echo $POETRY
           PYTHON=$(which python)
           echo $PYTHON
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
-      - name: Generate coverage report and run tests
-        run: |
           sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -40,11 +40,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python${{ matrix.python-version }}
           sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
-          sudo apt-get install -y git tmux redis net-tools
+          sudo apt-get install -y python3-setuptools git tmux redis net-tools
           sudo which python3
           sudo python3 -m pip install --upgrade pip
-          sudo python3 -m pip install setuptools -U
-          sudo python3 -m pip install poetry
+          sudo python3 -m pip install wheel poetry
       - name: Install
         run: |
           sudo poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -53,6 +53,11 @@ jobs:
           sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
       - name: Generate coverage report and run tests
         run: |
+          POETRY=$(which poetry)
+          echo $POETRY
+          PYTHON=$(which python)
+          echo $PYTHON
+          sudo update-alternatives --install /usr/bin/python3 python3 $PYTHON 1
           sudo $POETRY run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -45,6 +45,7 @@ jobs:
           $HOME/.poetry/bin/poetry install
       - name: Generate coverage report and run tests
         run: |
+          sudo $HOME/.poetry/bin/poetry env use /home/runner/.cache/pypoetry/virtualenvs/*-py${{ matrix.python-version }}
           sudo $HOME/.poetry/bin/poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -17,9 +17,14 @@ jobs:
       fail-fast: false
       # max-parallel: 9
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04]
         python-version: [3.6, 3.7, 3.8]
         experimental: [false]
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.8
+            experimental: true
+            name: Experimental build - latest Ubuntu
           #- python-version: 3.9
           #  os: ubuntu-18.04
           #  experimental: true
@@ -34,13 +39,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          sudo pip3 install poetry
+          python -m pip install --upgrade pip
+          python -m pip install poetry
       - name: Install
         run: |
-          sudo poetry install
+          poetry install
       - name: Generate coverage report and run tests
         run: |
-          sudo poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
+          poetry run python3 -m pytest tests -sv --cov=jumpscale --cov-report=xml
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          sudo $pythonLocation -m pip install --upgrade pip
-          sudo $pythonLocation -m pip install poetry
+          sudo $pythonLocation/python -m pip install --upgrade pip
+          sudo $pythonLocation/python -m pip install poetry
       - name: Install
         run: |
           poetry install

--- a/.github/workflows/jsng-ci.yml
+++ b/.github/workflows/jsng-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3-setuptools tmux redis net-tools
-          sudo python -m pip install poetry
+          python -m pip install poetry
       - name: Install
         run: |
           sudo poetry install


### PR DESCRIPTION
### Description

fixing issue #572 with js-ng current workflow, the problem was `setup-python` github action sets a new python Installation for the current user `runner` while using `sudo` with pip makes poetry get installed for default `root` Python installation that comes preinstalled with the system, which in the case of ubuntu 18, was 3.6.

verifying that the issue solved from the actions job log:
**with 3.8**
```
============================= test session starts ==============================
platform linux -- Python 3.8.7, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/runner/work/js-ng/js-ng/.venv/bin/python3
```
**with 3.7**
```
============================= test session starts ==============================
platform linux -- Python 3.7.10, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/runner/work/js-ng/js-ng/.venv/bin/python3
```
### Changes
in this modified workflow:
- now `poetry install` will pick the correct Python environment sets by the GitHub action matrix
- disabling the python 3.9 build for the current incompatibility issues.

### Related Issues

closes #572
