### PR TITLE
support configuring default logger

### DIFF
--- a/jumpscale/core/config/config.py
+++ b/jumpscale/core/config/config.py
@@ -114,6 +114,7 @@ def get_default_config():
         "debug": True,
         "shell": "ptpython",
         "logging": {
+            "default": {"enabled": True, "level": 10,},
             "redis": {
                 "enabled": True,
                 "level": 15,

--- a/jumpscale/core/logging/__init__.py
+++ b/jumpscale/core/logging/__init__.py
@@ -1,3 +1,6 @@
+import sys
+
+
 def export_module_as():
 
     from jumpscale.loader import j
@@ -7,6 +10,11 @@ def export_module_as():
     config = j.core.config.config.get_config().get("logging")
 
     if config:
+        # remove the default stderr handler
+        logger.remove_handler(0)
+        if config["default"]["enabled"]:
+            logger.add_handler(sys.stderr, level=config["default"]["level"])
+
         # configure redis handler if enabled
         if config["redis"]["enabled"] and j.core.db:
             redis_config = config["redis"]

--- a/jumpscale/core/logging/logging.py
+++ b/jumpscale/core/logging/logging.py
@@ -46,7 +46,7 @@ class Logger:
 
         takes the same parameters of loguru.logger.add
         """
-        self._logger.add(*args, **kwargs)
+        return self._logger.add(*args, **kwargs)
 
     def add_custom_handler(self, name: str, handler: LogHandler, *args, **kwargs):
         """
@@ -56,7 +56,18 @@ class Logger:
             handler (LogHandler): handler function
         """
         setattr(self, name, handler)
-        self._logger.add(handler._handle, **kwargs)
+        return self._logger.add(handler._handle, **kwargs)
+
+    def remove_handler(self, handler_id: int):
+        """
+        Remove loguru handler by id
+
+        The pre-configured handler has the id of `0`
+
+        Args:
+            handler_id (int): handler id that was returned by `add_handler` method
+        """
+        self._logger.remove(handler_id)
 
     def _log(self, level, message, *args, category, data, exception=None):
         self._logger.opt(depth=2, exception=exception).bind(category=category, data=data).log(level, message, *args)


### PR DESCRIPTION
### Description

Allow enabling/disabling default loguru stderr handler and setting its level.

### Changes

- Add default config for default logger
- Re-add default handler with the new level

### Related Issues

None

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
