### PR TITLE
improving get_latest_remote_tag() in git module

### DIFF
--- a/jumpscale/tools/git/__init__.py
+++ b/jumpscale/tools/git/__init__.py
@@ -213,7 +213,9 @@ def get_latest_remote_tag(repo_path):
     Returns:
         str: the latest tag of the remote repository
     """
-    rc, out, err = j.sals.process.execute("git ls-remote --tags --refs | sort -t '/' -k 3 -V | tail -n1 | sed 's/.*\///'", cwd=repo_path)
+    rc, out, err = j.sals.process.execute(
+        "git ls-remote --tags --refs | sort -t '/' -k 3 -V | tail -n1 | sed 's/.*\///'", cwd=repo_path
+    )
     if rc != 0:
         raise j.exceptions.Runtime(f"Failed to fetch latest remote release. {err}")
     latest_remote_tag = out.rstrip("\n")

--- a/jumpscale/tools/git/__init__.py
+++ b/jumpscale/tools/git/__init__.py
@@ -205,7 +205,7 @@ def find_git_path(path, die=True):
 
 def get_latest_remote_tag(repo_path):
     """
-    Get the latest tag of a remote repository
+    retrive the latest tag of a remote upstream repository
 
     Args:
         repo_path (str): path to the local git repository
@@ -213,11 +213,8 @@ def get_latest_remote_tag(repo_path):
     Returns:
         str: the latest tag of the remote repository
     """
-    try:
-        _, out, _ = j.sals.process.execute(
-            "git ls-remote --tags --refs --sort='v:refname' | tail -n1 | sed 's/.*\///'", cwd=repo_path
-        )
-        latest_remote_tag = out.rstrip("\n")
-    except Exception as e:
-        raise j.exceptions.Runtime(f"Failed to fetch remote releases. {str(e)}")
+    rc, out, err = j.sals.process.execute("git ls-remote --tags --refs | sort -t '/' -k 3 -V | tail -n1 | sed 's/.*\///'", cwd=repo_path)
+    if rc != 0:
+        raise j.exceptions.Runtime(f"Failed to fetch latest remote release. {err}")
+    latest_remote_tag = out.rstrip("\n")
     return latest_remote_tag


### PR DESCRIPTION
removing the usage of git built-in --sort option as it is not available in git < 2.18. the sort Linux command was used instead.
ATM the git version used in our VDC deployer is 2.17
